### PR TITLE
Make destination the first argument for all dependency `constructors`

### DIFF
--- a/r3/job.py
+++ b/r3/job.py
@@ -217,8 +217,8 @@ class JobDependency(Dependency):
 
     def __init__(
         self,
-        job: Union[Job, str],
         destination: Union[os.PathLike, str],
+        job: Union[Job, str],
         source: Union[os.PathLike, str] = ".",
         query: Optional[str] = None,
         query_all: Optional[str] = None,
@@ -306,8 +306,8 @@ class QueryDependency(Dependency):
 
     def __init__(
         self,
-        query: str,
         destination: Union[os.PathLike, str],
+        query: str,
         source: Union[os.PathLike, str] = ".",
     ) -> None:
         """Initializes the query dependency.
@@ -374,8 +374,8 @@ class QueryAllDependency(Dependency):
 
     def __init__(
         self,
+        destination: Union[os.PathLike, str],
         query_all: str,
-        destination: Union[os.PathLike, str]
     ) -> None:
         """Initializes the query all dependency.
 
@@ -442,9 +442,9 @@ class GitDependency(Dependency):
 
     def __init__(
         self,
-        repository: str,
-        commit: Optional[str],
         destination: Union[os.PathLike, str],
+        repository: str,
+        commit: Optional[str] = None,
         source: Union[os.PathLike, str] = "",
         branch: Optional[str] = None,
         tag: Optional[str] = None,

--- a/r3/repository.py
+++ b/r3/repository.py
@@ -300,7 +300,7 @@ class Repository:
             raise ValueError(f"Cannot resolve dependency: {dependency.query}")
 
         return JobDependency(
-            result[0], dependency.destination, dependency.source, dependency.query
+            dependency.destination, result[0], dependency.source, dependency.query
         )
 
     def _resolve_query_all_dependency(
@@ -322,7 +322,7 @@ class Repository:
         for job in result:
             assert job.id is not None
             resolved_dependencies.append(JobDependency(
-                job, dependency.destination / job.id, query_all=dependency.query_all)
+                dependency.destination / job.id, job, query_all=dependency.query_all)
             )
 
         return resolved_dependencies
@@ -346,8 +346,8 @@ class Repository:
             commit = r3.utils.git_get_remote_head(repository_path)
         
         return GitDependency(
+            dependency.destination,
             dependency.repository,
             commit,
-            destination=dependency.destination,
             source=dependency.source,
         )

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -40,7 +40,7 @@ def storage_with_jobs(fs: FakeFilesystem) -> Storage:
     committed_job = storage.add(job)
 
     job._config["dependencies"] = [
-        JobDependency(committed_job, "previous_job").to_config()
+        JobDependency("previous_job", committed_job).to_config()
     ]
     job.metadata["tags"] = ["test", "test-latest"]
     job.timestamp = datetime.datetime(2021, 1, 3, 0, 0, 0)

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -215,7 +215,7 @@ def test_job_dependency_to_config():
 
 
 def test_job_dependency_hash_does_not_depend_on_destination() -> None:
-    dependency = r3.JobDependency(str(uuid.uuid4()), Path("data"))
+    dependency = r3.JobDependency(Path("data"), str(uuid.uuid4()))
 
     original_hash = dependency.hash()
 
@@ -386,9 +386,9 @@ def test_git_dependency_to_config():
 
 def test_git_dependency_hash_does_not_depend_on_destination() -> None:
     dependency = r3.GitDependency(
+        Path("model"),
         "https://github.com/user/model.git",
         "2ef52fde13642372a262fd9618159fe72835c813",
-        Path("model"),
     )
 
     original_hash = dependency.hash()
@@ -399,15 +399,14 @@ def test_git_dependency_hash_does_not_depend_on_destination() -> None:
 
 def test_git_dependency_is_resolved_if_commit_is_not_none() -> None:
     dependency = r3.GitDependency(
+        Path("model"),
         "https://github.com/user/model.git",
         "2ef52fde13642372a262fd9618159fe72835c813",
-        Path("model"),
     )
     assert dependency.is_resolved()
 
     dependency = r3.GitDependency(
+        Path("model"),
         "https://github.com/user/model.git",
-        None,
-        destination=Path("model"),
     )
     assert not dependency.is_resolved()

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -360,19 +360,19 @@ def test_checkout_job_dependency_symlinks_files(fs: FakeFilesystem):
     job = storage.add(job)
     assert job.id is not None
 
-    dependency = JobDependency(job.id, "destination")
+    dependency = JobDependency("destination", job.id)
     fs.makedir("/checkout1")
     storage.checkout_job_dependency(dependency, "/checkout1")
     assert Path("/checkout1/destination").is_symlink()
     assert Path("/checkout1/destination").resolve() == job.path.resolve()
 
-    dependency = JobDependency(job.id, "original_run.py", "run.py")
+    dependency = JobDependency("original_run.py", job.id, "run.py")
     fs.makedir("/checkout2")
     storage.checkout_job_dependency(dependency, "/checkout2")
     assert Path("/checkout2/original_run.py").is_symlink()
     assert Path("/checkout2/original_run.py").resolve() == job.path.resolve() / "run.py"
 
-    dependency = JobDependency(job.id, "destination", "output")
+    dependency = JobDependency("destination", job.id, "output")
     fs.makedir("/checkout3")
     storage.checkout_job_dependency(dependency, "/checkout3")
     assert Path("/checkout3/destination").is_symlink()


### PR DESCRIPTION
Changing the order was required to use a default value `commit=None` in the `GitDependency` constructor. Since the destination is the only attribute shared by all dependency classes, it makes sense to use this always as the first argument.