### PR TITLE
Fixed failing pytest tests related to git.

### DIFF
--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -29,7 +29,7 @@ DATA_PATH = Path(__file__).parent / "data"
 class ExampleGitRepository:
     def __init__(self, path: Union[str, Path]) -> None:
         self.path = Path(path)
-        execute(f"git init {self.path}")
+        execute(f"git init --initial-branch=main {self.path}")
         with open(self.path / "test.txt", "w") as file:
             file.write("original content")
         execute("git add test.txt", directory=self.path)


### PR DESCRIPTION

On systems that have the global git configuration for the default branch set to the old standard value "master" (`git config --global init.defaultBranch master`) 5 tests failed:


```
FAILED test/test_repository.py::test_repository_contains_git_dependency_fetches_all_branches - executor.ExternalCommandFailed: External command failed with exit code 128!
FAILED test/test_repository.py::test_commit_adds_git_tags_to_prevent_garbage_collection - executor.ExternalCommandFailed: External command failed with exit code 128!
FAILED test/test_repository.py::test_resolve_git_dependency_from_url - executor.ExternalCommandFailed: External command failed with exit code 128!
FAILED test/test_repository.py::test_resolve_git_dependency_from_branch - executor.ExternalCommandFailed: External command failed with exit code 128!
FAILED test/test_repository.py::test_resolve_git_dependency_from_tag - executor.ExternalCommandFailed: External command failed with exit code 128!
```


I explicitly set default branch name of the example git repository for tests to "main" upon initialization. This fixes the test cases.

