### PR TITLE
Eliminated references to jobs by absolute paths (CLI tool).

### DIFF
--- a/r3/repository.py
+++ b/r3/repository.py
@@ -202,6 +202,26 @@ class Repository:
         self._storage.remove(job)
         self._index.remove(job)
 
+    def __getitem__(self, key):
+        """Get jobs by their ID with the repository[job_id] syntax."""
+        return self.get_job_by_id(key)
+
+    def get_job_by_id(self, job_id: str):
+        """Returns the job with the given ID.
+
+        If the job does not exist in the repository it will raise a KeyError.
+
+        Parameters:
+            job_id: ID of the job to retrieve from the repository.
+
+        Returns:
+            The job with the given ID.
+        """
+        try:
+            return self._storage.get(job_id=job_id)
+        except FileNotFoundError:
+            raise KeyError(f"Job with ID {job_id} not found in this repository.")
+
     def find(self, query: Dict[str, Any], latest: bool = False) -> List[Job]:
         """Finds jobs by a query.
         

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -739,3 +739,17 @@ def test_resolve_job(repository: Repository) -> None:
     assert all(dependency.is_resolved() for dependency in resolved_job.dependencies)
     assert isinstance(resolved_job.dependencies[0], JobDependency)
     assert resolved_job.dependencies[0].job == committed_job.id
+
+def test_repository_get_job_by_id(repository: Repository) -> None:
+    job = get_dummy_job("base")
+    job = repository.commit(job)
+    
+    retrieved_job = repository.get_job_by_id(job.id)
+    retrieved_job_syntax_sugar = repository[job.id]
+
+    assert retrieved_job.id == retrieved_job_syntax_sugar.id == job.id
+
+    with pytest.raises(KeyError):
+        repository.get_job_by_id("invalid-job-id")
+    with pytest.raises(KeyError):
+        repository["invalid-job-id"]


### PR DESCRIPTION
Eliminated references to jobs by absolute paths.

For the CLI interface jobs are now always referenced by their ID
relative to the repository.
No more absolute paths are used, instead the commands `checkout` and `remove` get an extra option (`--repository`) or use the environment variable `R3_REPOSITORY`.

So instead of:

```
r3 checkout /absolute/path/to/repo/jobs/<uuid> ./target/path
```

use:

```
r3 checkout --repository=/path/to/repo <uuid> ./target/path
```

or, if `R3_REPOSITORY` is set as environment variable:

```
r3 checkout <uuid> ./target/path
```

**Beware:** All outputs (e.g. `r3 find`, `r3 commit`) also output only the job IDs and not the full path to the job. This may break some tools that build upon the CLI interface. 

---

I also added a method to get jobs by their ID to the repository class.
Added a test case for the method.

```
job: Job = repository.get_job_by_id(job_id) # Gets you the Job object.
job: Job = repository[job_id] # Does the same as the above (syntactic sugar)
```