### PR TITLE
Feature recursive checkout

### DIFF
--- a/r3/job.py
+++ b/r3/job.py
@@ -346,7 +346,7 @@ class JobDependency(Dependency):
         if self.query_all is not None:
             config["query_all"] = self.query_all
 
-        if self.recursive_checkout is not True:
+        if not self.recursive_checkout:
             config["recursive_checkout"] = self.recursive_checkout
 
         return config

--- a/r3/job.py
+++ b/r3/job.py
@@ -62,7 +62,7 @@ class Job:
 
     def uses_cached_metadata(self) -> bool:
         """Returns `True` if the metadata was loaded from the cache.
-        
+
         Metadata from the cache might be outdated. Use `reload_metadata` to reload the
         metadata from disk.
         """
@@ -79,7 +79,7 @@ class Job:
 
     def save_metadata(self) -> None:
         """Saves the job metadata to the metadata file.
-        
+
         This method has to be called after modifying the metadata dictionary.
         """
         with open(self.path / "metadata.yaml", "w") as metadata_file:
@@ -88,7 +88,7 @@ class Job:
     @property
     def timestamp(self) -> Optional[datetime]:
         """Returns the date and time when this job was committed.
-        
+
         Returns:
             A datetime object representing the date and time when this job was
             committed. If the job is not committed, this returns `None`.
@@ -98,7 +98,7 @@ class Job:
 
         if "timestamp" in self._config:
             return datetime.fromisoformat(self._config["timestamp"])
-        
+
         return None
 
     @timestamp.setter
@@ -107,7 +107,7 @@ class Job:
 
     def uses_cached_timestamp(self) -> bool:
         """Returns `True` if the timestamp was loaded from the cache.
-        
+
         The timestamp of a job is fixed, so it cannot be outdated.
         """
         return self._timestamp is not None
@@ -237,7 +237,7 @@ class Dependency(abc.ABC):
     @abc.abstractmethod
     def is_resolved(self) -> bool:
         """Returns `True` if the dependency is resolved.
-        
+
         A dependency is resolved if it references a specific job or commit.
         """
         raise NotImplementedError
@@ -256,18 +256,21 @@ class JobDependency(Dependency):
         destination: Union[os.PathLike, str],
         job: Union[Job, str],
         source: Union[os.PathLike, str] = ".",
+        recursive_checkout: bool = True,
         find_latest: Optional[Dict[str, Any]] = None,
         find_all: Optional[Dict[str, Any]] = None,
         query: Optional[str] = None,
         query_all: Optional[str] = None,
     ) -> None:
         """Initializes the job dependency.
-        
+
         Parameters:
             job: Job instance or job id.
             destination: Path relative to the job to which the dependency will be
                 checked out.
             source: Path relative to the source job to be checked out.
+            recursive_checkout: If `True`, checking out this JobDependency will also
+                recursively checkout all dependencies of the job.
             find_latest: If this job was resolved from a FindLatestDependency, this is
                 the query that was used.
             find_all: If this job was resolved from a FindAllDependency, this is the
@@ -288,6 +291,7 @@ class JobDependency(Dependency):
             self.job = job
 
         self.source = Path(source)
+        self.recursive_checkout = recursive_checkout
         self.find_latest = find_latest
         self.find_all = find_all
         self.query = query
@@ -296,7 +300,7 @@ class JobDependency(Dependency):
     @staticmethod
     def from_config(config: Dict[str, str]) -> "JobDependency":
         """Creates a JobDependency instance from a config dictionary.
-        
+
         Example:
 
             config = {
@@ -313,7 +317,7 @@ class JobDependency(Dependency):
         Parameters:
             config: A dictionary representing the dependency. See the example above for
                 the format of the dictionary.
-        
+
         Returns:
             A JobDependency instance.
         """
@@ -321,7 +325,7 @@ class JobDependency(Dependency):
 
     def to_config(self) -> Dict[str, Any]:
         """Returns a config dictionary representing the dependency.
-        
+
         See `from_config` for an example.
         """
         config: Dict[str, Any] = {
@@ -332,7 +336,7 @@ class JobDependency(Dependency):
 
         if self.find_latest is not None:
             config["find_latest"] = self.find_latest
-        
+
         if self.find_all is not None:
             config["find_all"] = self.find_all
 
@@ -341,6 +345,9 @@ class JobDependency(Dependency):
 
         if self.query_all is not None:
             config["query_all"] = self.query_all
+
+        if self.recursive_checkout is not True:
+            config["recursive_checkout"] = self.recursive_checkout
 
         return config
 
@@ -361,6 +368,7 @@ class FindLatestDependency(Dependency):
         destination: Union[os.PathLike, str],
         query: Dict[str, Any],
         source: Union[os.PathLike, str] = ".",
+        recursive_checkout: bool = True,
     ) -> None:
         """Initializes the query dependency.
 
@@ -369,15 +377,18 @@ class FindLatestDependency(Dependency):
             destination: Path relative to the job to which the dependency will be
                 checked out.
             source: Path relative to the source job to be checked out.
+            recursive_checkout: If `True`, checking out this FindLatestDependency will
+                also recursively checkout all dependencies of the job.
         """
         super().__init__(destination)
         self.source = Path(source)
         self.query = query
-    
+        self.recursive_checkout = recursive_checkout
+
     @staticmethod
     def from_config(config: Dict[str, Any]) -> "FindLatestDependency":
         """Creates a QueryDependency instance from a config dictionary.
-        
+
         Example:
 
             config = {
@@ -389,7 +400,7 @@ class FindLatestDependency(Dependency):
             }
 
             dependency = FindLatestDependency.from_config(config)
-        
+
         Parameters:
             config: A dictionary representing the dependency. See the example above for
                 the format of the dictionary.
@@ -400,14 +411,19 @@ class FindLatestDependency(Dependency):
 
     def to_config(self) -> Dict[str, Any]:
         """Returns a config dictionary representing the dependency.
-        
+
         See `from_config` for an example.
         """
-        return {
+        config = {
             "destination": str(self.destination),
             "find_latest": self.query,
             "source": str(self.source),
         }
+
+        if not self.recursive_checkout:
+            config["recursive_checkout"] = self.recursive_checkout
+
+        return config
 
     def is_resolved(self) -> bool:
         """Returns `True` if the dependency is resolved."""
@@ -415,7 +431,7 @@ class FindLatestDependency(Dependency):
 
     def hash(self) -> str:
         """Raises an error.
-        
+
         FindLatestDependencies cannot be hashed because the hash would depend on the
         result of the query, which is not known at the time of creating the dependency.
 
@@ -427,11 +443,12 @@ class FindLatestDependency(Dependency):
 
 class FindAllDependency(Dependency):
     """A dependency to all jobs determined by a query."""
-    
+
     def __init__(
         self,
         destination: Union[os.PathLike, str],
         query: Dict[str, Any],
+        recursive_checkout: bool = True,
     ) -> None:
         """Initializes the find all dependency.
 
@@ -444,14 +461,17 @@ class FindAllDependency(Dependency):
             destination: Base path relative to the job to which the jobs will be checked
                 out. Each job will be checked out to a subdirectory of this path with
                 the job id as the name of the subdirectory.
+            recursive_checkout: If `True`, checking out this FindAllDependency will also
+                recursively checkout all dependencies of the jobs.
         """
         super().__init__(destination)
         self.query = query
+        self.recursive_checkout = recursive_checkout
 
     @staticmethod
     def from_config(config: Dict[str, Any]) -> "FindAllDependency":
         """Creates a FindAllDependency instance from a config dictionary.
-        
+
         Example:
 
             config = {
@@ -462,7 +482,7 @@ class FindAllDependency(Dependency):
             }
 
             dependency = FindAllDependency.from_config(config)
-        
+
         Parameters:
             config: A dictionary representing the dependency. See the example above for
                 the format of the dictionary.
@@ -476,10 +496,15 @@ class FindAllDependency(Dependency):
 
         See `from_config` for an example.
         """
-        return {
+        config = {
             "find_all": self.query,
             "destination": str(self.destination),
         }
+
+        if not self.recursive_checkout:
+            config["recursive_checkout"] = self.recursive_checkout
+
+        return config
 
     def is_resolved(self) -> bool:
         """Returns `True` if the dependency is resolved."""
@@ -527,7 +552,7 @@ class QueryDependency(Dependency):
     @staticmethod
     def from_config(config: Dict[str, str]) -> "QueryDependency":
         """Creates a QueryDependency instance from a config dictionary.
-        
+
         Example:
 
             config = {
@@ -537,7 +562,7 @@ class QueryDependency(Dependency):
             }
 
             dependency = QueryDependency.from_config(config)
-        
+
         Parameters:
             config: A dictionary representing the dependency. See the example above for
                 the format of the dictionary.
@@ -546,7 +571,7 @@ class QueryDependency(Dependency):
 
     def to_config(self) -> Dict[str, str]:
         """Returns a config dictionary representing the dependency.
-        
+
         See `from_config` for an example.
         """
         return {
@@ -561,7 +586,7 @@ class QueryDependency(Dependency):
 
     def hash(self) -> str:
         """Raises an error.
-        
+
         QueryDependencies cannot be hashed because the hash would depend on the result
         of the query, which is not known at the time of creating the dependency.
 
@@ -602,7 +627,7 @@ class QueryAllDependency(Dependency):
     @staticmethod
     def from_config(config: Dict[str, str]) -> "QueryAllDependency":
         """Creates a QueryAllDependency instance from a config dictionary.
-        
+
         Example:
 
             config = {
@@ -611,7 +636,7 @@ class QueryAllDependency(Dependency):
             }
 
             dependency = QueryAllDependency.from_config(config)
-        
+
         Parameters:
             config: A dictionary representing the dependency. See the example above for
                 the format of the dictionary.
@@ -657,7 +682,7 @@ class GitDependency(Dependency):
         tag: Optional[str] = None,
     ) -> None:
         """Initializes the git dependency.
-        
+
         Parameters:
             repository: URL of the git repository. Currently, only github.com is
                 supported.
@@ -701,7 +726,7 @@ class GitDependency(Dependency):
     @staticmethod
     def from_config(config: Dict[str, str]) -> "GitDependency":
         """Creates a GitDependency instance from a config dictionary.
-        
+
         Example:
 
             config = {
@@ -710,15 +735,15 @@ class GitDependency(Dependency):
                 "source": "src/model",
                 "destination": "model",
             }
-        
+
             dependency = GitDependency.from_config(config)
-        
+
         Parameters:
             config: A dictionary representing the dependency. See the example above for
                 the format of the dictionary.
 
         Returns:
-            A GitDependency instance.        
+            A GitDependency instance.
         """
         return GitDependency(**config)
 

--- a/r3/repository.py
+++ b/r3/repository.py
@@ -95,10 +95,10 @@ class Repository:
 
     def __contains__(self, item: Union[Job, Dependency]) -> bool:
         """Checks whether a job or dependency is contained in this repository.
-        
+
         Parameters:
             item: The job or dependency to check for.
-        
+
         Returns:
             Whether the given job or dependency is contained in this repository.
         """
@@ -139,10 +139,10 @@ class Repository:
 
     def commit(self, job: Job) -> Job:
         """Commits a job to the repository.
-        
+
         Parameters:
             job: The job to commit.
-        
+
         Returns:
             The committed job. Compared to the original job, the returned job has an id
             and the path is changed to the location in the repository.
@@ -164,7 +164,7 @@ class Repository:
         self, item: Union[Dependency, Job], path: Union[str, os.PathLike]
     ) -> None:
         """Checks out a job or dependency to the given path.
-        
+
         Parameters:
             item: The job or dependency to check out.
             path: The path to check out the job or dependency to.
@@ -179,10 +179,10 @@ class Repository:
 
     def remove(self, job: Job) -> None:
         """Removes a job from the repository.
-        
+
         Parameters:
             job: The job to remove.
-        
+
         Raises:
             ValueError: If the job is not contained in this repository or if other jobs
                 depend on it.
@@ -226,7 +226,7 @@ class Repository:
 
     def find(self, query: Dict[str, Any], latest: bool = False) -> List[Job]:
         """Finds jobs by a query.
-        
+
         Parameters:
             query: The mongo-style query document to find jobs by.
             latest: Whether to return the latest job or all jobs with the given tags.
@@ -238,11 +238,11 @@ class Repository:
 
     def find_dependents(self, job: Job, recursive: bool = False) -> Set[Job]:
         """Finds jobs that depend on the given job.
-        
+
         Parameters:
             job: The job to find dependents for.
             recursive: Whether to find dependents recursively.
-        
+
         Returns:
             The jobs that depend on the given job.
         """
@@ -262,13 +262,13 @@ class Repository:
         item: Union[Job, Dependency],
     ) -> Union[Job, Dependency, List[JobDependency]]:
         """Resolves a job or dependency.
-        
+
         A job or dependency is resolved by replacing query dependencies with concrete
         dependencies.
 
         Parameters:
             item: The job or dependency to resolve.
-        
+
         Returns:
             The resolved job or dependency. A query dependency might resolve to multiple
             concrete dependencies, in which case a list of dependencies is returned.
@@ -310,7 +310,7 @@ class Repository:
             dependency.to_config() for dependency in job.dependencies
         ]
         return job
-    
+
     def _resolve_find_latest_dependency(
         self,
         dependency: FindLatestDependency,
@@ -325,6 +325,7 @@ class Repository:
             job=result[0],
             source=dependency.source,
             find_latest=dependency.query,
+            recursive_checkout=dependency.recursive_checkout,
         )
 
     def _resolve_find_all_dependency(
@@ -339,7 +340,10 @@ class Repository:
         for job in result:
             assert job.id is not None
             resolved_dependencies.append(JobDependency(
-                dependency.destination / job.id, job, find_all=dependency.query
+                destination=dependency.destination / job.id,
+                job=job,
+                find_all=dependency.query,
+                recursive_checkout=dependency.recursive_checkout,
             ))
 
         return resolved_dependencies
@@ -393,7 +397,7 @@ class Repository:
         repository_path = self.path / dependency.repository_path
         if not repository_path.exists():
             execute(f"git clone --bare {dependency.repository} {repository_path}")
-        
+
         if dependency.branch is not None:
             commit = r3.utils.git_get_remote_branch_head(
                 repository_path, dependency.branch
@@ -406,7 +410,7 @@ class Repository:
                 raise ValueError(f"Tag not found: {dependency.tag}")
         else:
             commit = r3.utils.git_get_remote_head(repository_path)
-        
+
         return GitDependency(
             dependency.destination,
             dependency.repository,

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -73,7 +73,7 @@ def test_job_timestamp_caching() -> None:
 
     job = r3.Job(job_path)
     assert not job.uses_cached_timestamp()
- 
+
     job = r3.Job(job_path, cached_timestamp=datetime.datetime(2021, 1, 1, 0, 0, 0))
     assert job.uses_cached_timestamp()
 
@@ -130,6 +130,7 @@ def test_depedency_from_config() -> None:
         "source": "output",
         "destination": "data",
         "query": "#query",
+        "recursive_checkout": False,
     }
 
     dependency = r3.Dependency.from_config(config)
@@ -139,6 +140,7 @@ def test_depedency_from_config() -> None:
         "find_latest": {"tags": "test"},  # type: ignore
         "source": "output",
         "destination": "data",
+        "recursive_checkout": False,
     }
 
     dependency = r3.Dependency.from_config(config)
@@ -147,6 +149,7 @@ def test_depedency_from_config() -> None:
     config = {
         "find_all": {"tags": "test"},  # type: ignore
         "destination": "data",
+        "recursive_checkout": True,
     }
 
     dependency = r3.Dependency.from_config(config)
@@ -192,6 +195,7 @@ def test_job_dependency_from_config_defaults() -> None:
     assert dependency.source == Path(".")
     assert dependency.query is None
     assert dependency.query_all is None
+    assert dependency.recursive_checkout
 
 
 def test_job_dependency_from_config() -> None:
@@ -200,6 +204,7 @@ def test_job_dependency_from_config() -> None:
         "source": "output",
         "destination": "data",
         "query": "#query",
+        "recursive_checkout": False,
     }
 
     dependency = r3.JobDependency.from_config(config)
@@ -209,6 +214,7 @@ def test_job_dependency_from_config() -> None:
     assert dependency.destination == Path(config["destination"])
     assert dependency.query == config["query"]
     assert dependency.query_all is None
+    assert dependency.recursive_checkout == config["recursive_checkout"]
 
     config = {
         "job": str(uuid.uuid4()),
@@ -224,15 +230,17 @@ def test_job_dependency_from_config() -> None:
     assert dependency.destination == Path(config["destination"])
     assert dependency.query is None
     assert dependency.query_all == config["query_all"]
+    assert dependency.recursive_checkout
 
 
 def test_job_dependency_to_config():
-    dependency = r3.JobDependency(str(uuid.uuid4()), Path("data"))
+    dependency = r3.JobDependency(str(uuid.uuid4()), Path("data"), recursive_checkout=False)
 
     assert dependency.to_config() == {
         "job": dependency.job,
         "source": ".",
         "destination": str(dependency.destination),
+        "recursive_checkout": False,
     }
 
     dependency = r3.JobDependency(
@@ -329,11 +337,13 @@ def test_find_latest_dependency_from_config() -> None:
     assert dependency.destination == Path(config["destination"])  # type: ignore
     assert dependency.query == config["find_latest"]
     assert dependency.source == Path(".")
+    assert dependency.recursive_checkout
 
     config = {
         "find_latest": {"tags": "test"},
         "source": "output",
         "destination": "data",
+        "recursive_checkout": False,
     }
 
     dependency = r3.FindLatestDependency.from_config(config)
@@ -341,6 +351,7 @@ def test_find_latest_dependency_from_config() -> None:
     assert dependency.destination == Path(config["destination"])  # type: ignore
     assert dependency.query == config["find_latest"]
     assert dependency.source == Path(config["source"])  # type: ignore
+    assert dependency.recursive_checkout == config["recursive_checkout"]
 
 
 def test_find_latest_dependency_to_config():
@@ -352,12 +363,13 @@ def test_find_latest_dependency_to_config():
         "destination": str(dependency.destination),
     }
 
-    dependency = r3.FindLatestDependency(Path("data"), {"tags": "test"}, Path("output"))
+    dependency = r3.FindLatestDependency(Path("data"), {"tags": "test"}, Path("output"), recursive_checkout=False)
 
     assert dependency.to_config() == {
         "find_latest": dependency.query,
         "source": str(dependency.source),
         "destination": str(dependency.destination),
+        "recursive_checkout": False,
     }
 
 
@@ -379,13 +391,26 @@ def test_find_all_dependency_from_config() -> None:
     assert dependency.destination == Path(config["destination"])  # type: ignore
     assert dependency.query == config["find_all"]
 
+    config = {
+        "find_all": {"tags": "test"},
+        "destination": "data",
+        "recursive_checkout": False,
+    }
+
+    dependency = r3.FindAllDependency.from_config(config)
+
+    assert dependency.destination == Path(config["destination"])  # type: ignore
+    assert dependency.query == config["find_all"]
+    assert dependency.recursive_checkout == config["recursive_checkout"]
+
 
 def test_find_all_dependency_to_config():
-    dependency = r3.FindAllDependency(Path("data"), {"tags": "test"})
+    dependency = r3.FindAllDependency(Path("data"), {"tags": "test"}, recursive_checkout=False)
 
     assert dependency.to_config() == {
         "find_all": dependency.query,
         "destination": str(dependency.destination),
+        "recursive_checkout": False,
     }
 
 

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -57,7 +57,7 @@ class ExampleGitRepository:
             file.write("forced content")
         execute("git add test.txt", directory=self.path)
         execute("git commit --amend -m 'Force update'", directory=self.path)
-    
+
     def add_tag(self, tag: str) -> None:
         execute(f"git tag {tag} -m 'Test tag'", directory=self.path)
 
@@ -527,6 +527,7 @@ def test_resolve_query_dependency(repository: Repository) -> None:
     resolved_dependency = repository.resolve(dependency)
     assert isinstance(resolved_dependency, JobDependency)
     assert resolved_dependency.job == job.id
+    assert resolved_dependency.recursive_checkout
 
     with pytest.raises(ValueError):
         repository.resolve(QueryDependency("destination", "#does-not-exist"))
@@ -538,11 +539,17 @@ def test_resolve_find_latest_dependency(repository: Repository) -> None:
     job.metadata["image_size"] = 28
     committed_job_1 = repository.commit(job)
 
-    dependency = FindLatestDependency("destination", {"tags": "test"})
+    dependency = FindLatestDependency(
+        "destination",
+        {"tags": "test"},
+        recursive_checkout=False
+    )
+
     resolved_dependency = repository.resolve(dependency)
     assert isinstance(resolved_dependency, JobDependency)
     assert resolved_dependency.job == committed_job_1.id
     assert resolved_dependency.source == dependency.source
+    assert not resolved_dependency.recursive_checkout
 
     job.metadata["tags"] = ["test", "test-again"]
     job.metadata["image_size"] = 32
@@ -552,6 +559,7 @@ def test_resolve_find_latest_dependency(repository: Repository) -> None:
     assert isinstance(resolved_dependency, JobDependency)
     assert resolved_dependency.job == committed_job_2.id
     assert resolved_dependency.source == dependency.source
+    assert not resolved_dependency.recursive_checkout
 
     dependency = FindLatestDependency(
         "destination",
@@ -562,6 +570,8 @@ def test_resolve_find_latest_dependency(repository: Repository) -> None:
     assert isinstance(resolved_dependency, JobDependency)
     assert resolved_dependency.job == committed_job_1.id
     assert resolved_dependency.source == dependency.source
+    assert resolved_dependency.recursive_checkout
+
 
 
 def test_resolve_find_latest_dependency_preserves_source(


### PR DESCRIPTION
This PR adds an option recursive_checkout to dependencies on jobs, which can be used to control whether depending jobs will be checked out including all their dependencies, or not.

Closes https://github.com/mtangemann/r3/issues/36.

The option defaults to True and can be set for job dependencies, findLatest dependencies and findAll dependencies. It's not yet implemented for the deprecated query and queryAll dependencies where it is always True. @mtangemann let me know if you would like me to implement it there as well.

I also added tests for all changes (so I think...)

my vscode removed quite a bit of whitespace. I think that makes sense, but let me know if you would like me to undo it. Then I have to figure out how to do this.