### PR TITLE
:bug: Fix ignore patterns lost when recursing into subdirectories

### DIFF
--- a/r3/utils.py
+++ b/r3/utils.py
@@ -24,12 +24,12 @@ def _find_files(path: Path, ignore_patterns: Iterable[str]) -> Iterable[Path]:
 
         elif child.is_dir():
             prefix = f"/{child.name}"
-            ignore_patterns = [
+            sub_patterns = [
                 pattern[len(prefix) :]
                 for pattern in ignore_patterns
                 if pattern.startswith(prefix)
             ]
-            yield from _find_files(child, ignore_patterns)
+            yield from _find_files(child, sub_patterns)
 
 
 def _is_ignored(path: Path, ignore_patterns: Iterable[str]):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,27 @@
+"""Unit tests for ``r3.utils``."""
+
+from pathlib import Path
+
+import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+import r3.utils
+
+
+def test_find_files_ignores_sibling_dirs_after_recursing_into_earlier_sibling(
+    fs: FakeFilesystem,
+) -> None:
+    """Ignore patterns must not be lost after recursing into a subdirectory.
+
+    Regression test: when _find_files recurses into a non-ignored subdirectory, it
+    was reassigning the `ignore_patterns` local variable. Subsequent siblings at the
+    same level were then checked against the stripped (possibly empty) sub-patterns
+    instead of the original ones, causing ignored dirs to be traversed.
+    """
+    fs.create_file("/job/run.py")
+    fs.create_file("/job/subdir/helper.py")   # non-ignored subdir comes first
+    fs.create_file("/job/cache/big_file.bin") # should be ignored
+
+    files = r3.utils.find_files(Path("/job"), ["/cache"])
+
+    assert Path("cache/big_file.bin") not in files

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 import r3.utils


### PR DESCRIPTION
_find_files was reassigning the ignore_patterns local variable during the directory iteration loop. After recursing into any non-ignored subdirectory, the original patterns were replaced by the (stripped) sub-patterns for that subdirectory, meaning all subsequent sibling entries were checked against the wrong patterns.

In practice this caused checked-out dependency directories (and any other ignored dirs) to be silently traversed and hashed if any non-ignored subdirectory happened to be iterated first. This could lead to:

- Commits taking extremely long (hashing entire dependency trees)
- Dependency files being incorrectly included in job.files and committed

Fixed by using a separate sub_patterns variable for recursion, leaving ignore_patterns intact for the rest of the loop.

Adds a regression test in test/test_utils.py.