### PR TITLE
:boom: Use job IDs instead of absolute paths in CLI commands

### DIFF
--- a/r3/cli.py
+++ b/r3/cli.py
@@ -57,22 +57,26 @@ def commit(path: Path, repository_path: Path) -> None:
     run.py
     r3.yaml
     $ r3 commit my/job
-    /repository/jobs/4b2146f3-5594-4f05-ae13-2e053ef7bfda
+    4b2146f3-5594-4f05-ae13-2e053ef7bfda
     ```
     """
     repository = r3.Repository(repository_path)
     job = r3.Job(path)
     job = repository.commit(job)
-    print(job.path)
+    print(job.id)
 
 
 @cli.command()
-@click.argument(
-    "job_path", type=click.Path(exists=True, file_okay=False, path_type=Path)
-)
+@click.argument("job_id", type=str)
 @click.argument("target_path", type=click.Path(exists=False, path_type=Path))
-def checkout(job_path: Path, target_path) -> None:
-    """Checks out the job at JOB_PATH to TARGET_PATH.
+@click.option(
+    "--repository",
+    "repository_path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    envvar="R3_REPOSITORY",
+)
+def checkout(job_id: str, target_path: Path, repository_path: Path) -> None:
+    """Checks out the job with JOB_ID to TARGET_PATH.
 
     This copies all job files from JOB_PATH in the R3 repository to the TARGET_PATH.
     The output folder and all dependencies will by symlinked. Checking out a job is
@@ -81,32 +85,38 @@ def checkout(job_path: Path, target_path) -> None:
 
     \b
     ```
-    $ r3 checkout /repository/jobs/4b2146f3-5594-4f05-ae13-2e053ef7bfda workdir
+    $ r3 checkout 4b2146f3-5594-4f05-ae13-2e053ef7bfda workdir
     $ ls workdir
     run.py
     data.csv -> /repository/jobs/6b189b64-8c7c-4609-b089-f69c7b3e0548/output/data.csv
     output/ -> /repository/jobs/4b2146f3-5594-4f05-ae13-2e053ef7bfda/output
     ```
     """
-    job_path = job_path.resolve()
-    repository = r3.Repository(job_path.parent.parent)
-    job = r3.Job(job_path, id=job_path.name)
+    repository = r3.Repository(repository_path)
+    job = repository.get_job_by_id(job_id)
     repository.checkout(job, target_path)
 
 
 @cli.command()
-@click.argument(
-    "job_path", type=click.Path(exists=True, file_okay=False, path_type=Path)
+@click.argument("job_id", type=str)
+@click.option(
+    "--repository",
+    "repository_path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    envvar="R3_REPOSITORY",
 )
-def remove(job_path: Path) -> None:
-    """Removes the job at JOB_PATH from the R3 repository.
+def remove(job_id: str, repository_path: Path) -> None:
+    """Removes the job with JOB_ID from the R3 repository.
 
-    If any other job in the R3 repository depends on the job at JOB_PATH, removing the
-    job will fail.
+    If any other job in the R3 repository depends on the job, removing it will fail.
     """
-    job_path = job_path.resolve()
-    repository = r3.Repository(job_path.parent.parent)
-    job = r3.Job(job_path, id=job_path.name)
+    repository = r3.Repository(repository_path)
+
+    try:
+        job = repository.get_job_by_id(job_id)
+    except KeyError as error:
+        print(error)
+        return
 
     try:
         repository.remove(job)
@@ -128,7 +138,7 @@ def remove(job_path: Path) -> None:
 )
 @click.option("--long/--short", "-l", default=False,
     help=(
-        "Whether to list only the job paths (--short) or also additional job "
+        "Whether to list only the job IDs (--short) or also additional job "
         "information (--long)."
     )
 )
@@ -149,7 +159,7 @@ def find(tags: Iterable[str], latest: bool, long: bool, repository_path: Path) -
             tags = " ".join(f"#{tag}" for tag in job.metadata.get("tags", []))
             print(f"{job.id} | {datetime} | {tags}")
         else:
-            print(job.path)
+            print(job.id)
 
 
 @cli.command()


### PR DESCRIPTION
Re-apply the change from commit 158a96b that was lost during a merge. Commands checkout, remove, commit, and find now consistently reference jobs by ID with --repository option, matching the existing edit command.