### PR TITLE
:bug: Exclude output/ from committed jobs by default

### DIFF
--- a/r3/job.py
+++ b/r3/job.py
@@ -117,7 +117,12 @@ class Job:
     def files(self) -> Mapping[Path, Path]:
         """Files belonging to this job."""
         if self._files is None:
-            ignore = self._config.get("ignore", [])
+            # Copy the config's ignore list rather than mutating it: it is written
+            # verbatim to the committed r3.yaml.
+            ignore = list(self._config.get("ignore", []))
+            # output is always ignored: it is mutable and must not be frozen into
+            # the committed job or its hashes.
+            ignore.append("/output")
 
             for dependency in self.dependencies:
                 ignore.append(f"/{dependency.destination}")

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -387,6 +387,40 @@ def test_commit_copies_nested_files(repository: Repository) -> None:
     )
 
 
+def test_commit_excludes_output_directory_by_default(
+    repository: Repository, tmp_path: Path
+) -> None:
+    """Commit should exclude ``output/`` from the committed job and its hashes.
+
+    ``output/`` holds re-runnable results. Per the repository format specification, its
+    contents are not part of the job's identity and must not be frozen into the
+    committed job. This must hold even when the job does not declare ``ignore:
+    [/output]``, and it must cover nested output files.
+    """
+    job_path = tmp_path / "job"
+    (job_path / "output" / "sub").mkdir(parents=True)
+    with open(job_path / "run.py", "w") as file:
+        file.write("print('hello')\n")
+    with open(job_path / "r3.yaml", "w") as file:
+        yaml.dump({"dependencies": []}, file)
+    with open(job_path / "output" / "top.txt", "w") as file:
+        file.write("top result\n")
+    with open(job_path / "output" / "sub" / "nested.txt", "w") as file:
+        file.write("nested result\n")
+
+    committed_job = repository.commit(Job(job_path))
+
+    # The committed job has an (empty) output directory; no output files are copied.
+    assert (committed_job.path / "output").is_dir()
+    assert list((committed_job.path / "output").iterdir()) == []
+
+    # No output files are folded into the job hashes, but regular files still are.
+    with open(committed_job.path / "r3.yaml") as config_file:
+        config = yaml.safe_load(config_file)
+    assert "run.py" in config["hashes"]
+    assert not any(path.startswith("output") for path in config["hashes"])
+
+
 def test_commit_adds_git_tags_to_prevent_garbage_collection(
     tmp_path: Path, mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
Closes #52.

`output/` holds a job's re-runnable results. Per the [repository format spec](docs/repository_format.md), its contents are excluded from the job hash and remain writable after commit — but the implementation only excluded `output/` when the job explicitly declared `ignore: [/output]`. So running a job locally before committing silently froze its results into the immutable job **and** folded them into the identity hash, contradicting the documented format.

## Change

`Job.files` now always excludes `/output`. The config's `ignore` list is copied rather than mutated, so `/output` (and dependency destinations) no longer leak into the committed `r3.yaml`.

## Test

Adds an end-to-end test committing a job with `output/top.txt` + `output/sub/nested.txt`, asserting the committed `output/` is empty and no `output/*` appears in the `r3.yaml` hashes (nested coverage included).

Full suite green (164 passed), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
