### PR TITLE
:bug: Fix packaging so non-editable installs are importable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,8 @@ lint.select = ["B", "E", "F", "FIX", "I", "T20"]
 
 
 [tool.setuptools]
-py-modules = ["r3"]
+packages = ["r3"]
+
+
+[tool.setuptools.dynamic]
+version = {file = "VERSION"}

--- a/r3/__init__.py
+++ b/r3/__init__.py
@@ -14,8 +14,25 @@ from r3.job import (
 )
 from r3.repository import Repository
 
-with open(Path(__file__).parent.parent / "VERSION", "r") as version_file:
-    __version__ = version_file.read().strip()
+
+def _read_version() -> str:
+    # Editable install / source tree: VERSION sits next to the package, so read it
+    # live. `git pull` bumping VERSION then takes effect without reinstalling.
+    version_file = Path(__file__).parent.parent / "VERSION"
+    if version_file.is_file():
+        return version_file.read_text().strip()
+
+    # Non-editable (wheel) install: VERSION is not shipped, so fall back to the
+    # version baked into the distribution metadata at build time.
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("r3")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = _read_version()
 
 __all__ = [
     "Dependency",

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,17 @@
+"""Tests for package version resolution."""
+
+from pathlib import Path
+
+import r3
+
+VERSION_FILE = Path(__file__).parent.parent / "VERSION"
+
+
+def test_version_matches_version_file() -> None:
+    """In a source tree / editable install, ``__version__`` reflects VERSION live.
+
+    This is the path exercised by the CLI's ``--version`` and by tests running
+    against an editable install, so it must track the on-disk VERSION file without
+    requiring a reinstall.
+    """
+    assert r3.__version__ == VERSION_FILE.read_text().strip()


### PR DESCRIPTION
Closes #53.

A non-editable install (`pip install` from a git URL, or from a built wheel/sdist) shipped an empty package: `import r3` raised `ModuleNotFoundError: No module named 'r3'`. Investigating turned up three coupled defects, all of which have to be fixed for an installed package to be importable and correctly versioned:

| Defect | Symptom |
|--------|---------|
| `py-modules = ["r3"]` treats the `r3/` package directory as a single-file module `r3.py`, which doesn't exist | build logs `file r3.py not found` / `no Python modules to install`; wheel contains only `dist-info/` |
| `dynamic = ["version"]` declared with **no** `[tool.setuptools.dynamic]` source | builds were versioned `0.0.0` |
| `__init__.py` read `VERSION` from `parent.parent` (outside the package) | even once code shipped, `import r3` would `FileNotFoundError` in a wheel, where `site-packages/r3/../VERSION` does not exist |

## Changes

- **`packages = ["r3"]`** so the package is actually shipped.
- **`[tool.setuptools.dynamic] version = {file = "VERSION"}`** so the build version comes from the `VERSION` file (and `VERSION` is included in the sdist).
- **`__version__` resolution**: read the `VERSION` file when present — i.e. in an editable install / source tree, so a `git pull` that bumps `VERSION` is picked up live without reinstalling — and fall back to the distribution metadata (`importlib.metadata`) for non-editable installs where `VERSION` isn't shipped.

`VERSION` stays at the repo root; there is no new package-data and no change to the editable-install behavior.

## Test

Adds `test/test_version.py` asserting `r3.__version__` tracks the on-disk `VERSION` file (the path used by the CLI's `--version` and by tests running against an editable install).

## Verification

Built a wheel + sdist with `uv build` and installed the wheel into a clean venv (from a neutral working directory, so the source tree can't shadow it):

- wheel now contains all 8 `r3/*.py` modules; built artifacts are `r3-0.5.0` (not `0.0.0`)
- sdist includes `VERSION`
- `import r3` and `import r3.cli` succeed; `r3.__version__ == "0.5.0"` (via the metadata fallback)
- `r3 --version` prints `0.5.0`

Full test suite green (165 passed), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
