### PR TITLE
:bug: Fix `r3 remove`'s refusal message and exit code

### DIFF
--- a/r3/cli.py
+++ b/r3/cli.py
@@ -115,13 +115,13 @@ def remove(job_id: str, repository_path: Path) -> None:
     try:
         job = repository.get_job_by_id(job_id)
     except KeyError as error:
-        print(error)
-        return
+        # `str` of a KeyError is the repr of its argument, which would add quotes.
+        raise click.ClickException(str(error.args[0])) from error
 
     try:
         repository.remove(job)
     except ValueError as error:
-        print(f"Error removing job: {error}")
+        raise click.ClickException(str(error)) from error
 
 
 @cli.command()

--- a/r3/repository.py
+++ b/r3/repository.py
@@ -194,9 +194,10 @@ class Repository:
 
         dependents = self._index.find_dependents(job)
         if len(dependents) > 0:
+            dependent_ids = sorted(str(dependent.id) for dependent in dependents)
             raise ValueError(
-                "Cannot remove job since other jobs depend on it: \n"
-                "\n".join(f"  - {dependent.id}" for dependent in dependents)
+                "Cannot remove job since other jobs depend on it:\n"
+                + "\n".join(f"  - {dependent_id}" for dependent_id in dependent_ids)
             )
 
         self._storage.remove(job)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,91 @@
+"""Unit tests for the R3 command line interface."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from r3.cli import cli
+from r3.job import Job, JobDependency
+from r3.repository import Repository
+
+DATA_PATH = Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> Repository:
+    return Repository.init(tmp_path / "repository")
+
+
+def get_dummy_job(name: str) -> Job:
+    path = DATA_PATH / "jobs" / name
+    return Job(path)
+
+
+def commit_dependent_job(repository: Repository, job: Job, destination: str) -> Job:
+    """Commits a job depending on the given job and returns it."""
+    assert job.id is not None
+
+    dependent_job = get_dummy_job("base")
+    dependency = JobDependency(destination, job.id)
+    dependent_job._dependencies = [dependency]
+    dependent_job._config["dependencies"] = [dependency.to_config()]
+
+    return repository.commit(dependent_job)
+
+
+def is_in_repository(repository: Repository, job_id: str) -> bool:
+    """Checks whether a job with the given ID exists in the repository.
+
+    ``job in repository`` only checks whether the job path points into the repository,
+    which stays true after the job has been removed.
+    """
+    try:
+        repository.get_job_by_id(job_id)
+    except KeyError:
+        return False
+    return True
+
+
+def test_remove_removes_job(repository: Repository) -> None:
+    job = repository.commit(get_dummy_job("base"))
+    assert job.id is not None
+
+    result = CliRunner().invoke(
+        cli, ["remove", job.id, "--repository", str(repository.path)]
+    )
+
+    assert result.exit_code == 0
+    assert not is_in_repository(repository, job.id)
+
+
+def test_remove_fails_if_other_jobs_depend_on_job(repository: Repository) -> None:
+    job = repository.commit(get_dummy_job("base"))
+    assert job.id is not None
+    dependent_job = commit_dependent_job(repository, job, "destination")
+    assert dependent_job.id is not None
+
+    result = CliRunner().invoke(
+        cli, ["remove", job.id, "--repository", str(repository.path)]
+    )
+
+    assert result.exit_code != 0
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert any(dependent_job.id in line for line in lines)
+    # The dependent must be reported with an explanation, not on its own. The exact
+    # wording is asserted in ``test_repository.py``.
+    assert len(lines) > 1
+    assert is_in_repository(repository, job.id)
+
+
+def test_remove_fails_if_job_does_not_exist(repository: Repository) -> None:
+    job_id = "00000000-0000-0000-0000-000000000000"
+
+    result = CliRunner().invoke(
+        cli, ["remove", job_id, "--repository", str(repository.path)]
+    )
+
+    assert result.exit_code != 0
+    assert job_id in result.output
+    # ``str(KeyError(...))`` is a repr and would wrap the whole message in quotes.
+    assert "Error: '" not in result.output

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -5,7 +5,7 @@ import os
 import stat
 from datetime import datetime
 from pathlib import Path
-from typing import Union
+from typing import Sequence, Union
 
 import pytest
 import yaml
@@ -70,6 +70,24 @@ def repository(tmp_path: Path) -> Repository:
 def get_dummy_job(name: str) -> Job:
     path = DATA_PATH / "jobs" / name
     return Job(path)
+
+
+def assert_lists_dependents(message: str, dependent_ids: Sequence[str]) -> None:
+    """Asserts that the message lists the given dependents below an explanation.
+
+    This checks the structure of the message rather than its wording, so that it can
+    be reworded freely: each dependent must be listed on a line of its own, in the
+    given order, below a line explaining the refusal. The explanation used to be
+    written as the *separator* between the dependents instead of as a prefix.
+    """
+    lines = [line.strip() for line in message.splitlines() if line.strip()]
+    listed = [line for line in lines if any(id in line for id in dependent_ids)]
+
+    assert len(listed) == len(dependent_ids)
+    for line, dependent_id in zip(listed, dependent_ids):
+        assert line.endswith(dependent_id)
+
+    assert lines[0] not in listed
 
 
 def test_init_fails_if_path_exists(tmp_path: Path) -> None:
@@ -486,11 +504,39 @@ def test_repository_remove_fails_if_other_jobs_depend_on_job(
     base_job._config["dependencies"] = [dependency.to_config()]
     dependent_job = repository.commit(base_job)
 
-    with pytest.raises(ValueError):
+    assert dependent_job.id is not None
+
+    with pytest.raises(ValueError) as exception_info:
         repository.remove(job)
+
+    assert_lists_dependents(str(exception_info.value), [dependent_job.id])
 
     repository.remove(dependent_job)
     repository.remove(job)
+
+
+def test_repository_remove_error_message_lists_all_dependents(
+    repository: Repository
+) -> None:
+    job = repository.commit(get_dummy_job("base"))
+    assert job.id is not None
+
+    dependent_ids = []
+    for index in range(2):
+        dependent_job = get_dummy_job("base")
+        dependency = JobDependency(f"destination{index}", job.id)
+        dependent_job._dependencies = [dependency]
+        dependent_job._config["dependencies"] = [dependency.to_config()]
+        dependent_job = repository.commit(dependent_job)
+        assert dependent_job.id is not None
+        dependent_ids.append(dependent_job.id)
+
+    with pytest.raises(ValueError) as exception_info:
+        repository.remove(job)
+
+    # Sorted, since ``Index.find_dependents`` returns an unordered set and the message
+    # should not depend on the iteration order.
+    assert_lists_dependents(str(exception_info.value), sorted(dependent_ids))
 
 
 def test_find_dependents_requires_job_id(repository: Repository) -> None:


### PR DESCRIPTION
Two independent defects made a refused `r3 remove` look like a glitch. "You cannot
delete a job that another committed job depends on" is a headline provenance
guarantee, but the refusal neither explained itself nor failed, so it could not be
scripted against. Both were found while building an r3 tutorial.

Kept as two commits so either can be reverted alone.

## 1. The explanation was swallowed (`r3/repository.py`)

```python
raise ValueError(
    "Cannot remove job since other jobs depend on it: \n"
    "\n".join(f"  - {dependent.id}" for dependent in dependents)
)
```

Python concatenates the two adjacent string literals *before* `.join` is called, so
the explanatory sentence became the **separator** rather than a prefix — a `+` was
missing. With one dependent the sentence vanished entirely; with two it appeared
between the job IDs:

```
Error removing job:   - uuid-BCannot remove job since other jobs depend on it:

  - uuid-A
```

The IDs are now also sorted, because `Index.find_dependents` returns an unordered
`set` — without that the message was nondeterministic even once concatenated
correctly, and could not be asserted on.

## 2. A refused `r3 remove` exited 0 (`r3/cli.py`)

Both failure paths only printed and returned, so the process exited 0 and a caller
could not distinguish "removed" from "refused" or "no such job". They now raise
`click.ClickException`, which reports the message on stderr and exits 1.

While adding coverage for the unknown-job path, a third defect turned up: `str()` of
a `KeyError` is the *repr* of its argument, so the message was printed wrapped in
quotes (`'Job with ID ... not found in this repository.'`). It is now unwrapped via
`args[0]`.

`init` still prints to stdout and calls `sys.exit(1)`; converting the remaining
commands to `ClickException` is deliberately left out of this PR.

## Result

```
$ r3 remove $UPSTREAM_JOB; echo "exit=$?"
Error: Cannot remove job since other jobs depend on it:
  - ce361644-a3e4-4dc4-863e-c749d878cd79
  - e3ce50dd-ff45-43eb-aa5d-6c34f8576719
exit=1
```

## Tests

`test_repository_remove_fails_if_other_jobs_depend_on_job` asserted only the
exception *type*, so a mangled message passed. It now asserts the **structure** of the
message — each dependent listed on a line of its own, below an explanation — rather
than its exact text, so the wording stays free to change while the defect stays
caught. A new `test_repository_remove_error_message_lists_all_dependents` covers the
two-dependent case: the variant that interleaved the sentence between the IDs, and one
that a single-dependent test alone would not catch.

Checked that this is not a hollow loosening — reintroducing the original bug fails all
three affected tests, while rewording the sentence *and* changing the bullet style
(`  - ` to `    * `) keeps them green. Note that asserting only "the dependent's ID
appears somewhere" would **not** have caught the original defect: the mangled
two-dependent message did contain both IDs.

`test/test_cli.py` is new (there was no CLI test module) and uses click's
`CliRunner` to cover the exit code and message for both failure paths plus the
successful removal.

Note that `test/test_cli.py` looks jobs up by ID rather than using
`job in repository`: `Storage.__contains__(Job)` only checks that the job's path
points into the repository, which stays true after the job has been removed, so it
cannot express "was removed". That pre-existing behaviour is left untouched here.

## Verification

- `make lint` clean (ruff + mypy); `make test` 168 passed, up from 165.
- `r3/cli.py` coverage 40% → 60%.
- `test/test_cli.py` verified against click 8.1.8, 8.2.1 and 8.4.2 — `uv.lock`
  resolves click 8.1.8 on Python 3.9 but 8.2.1 on 3.10+, so CI and a 3.9 dev
  environment do not run the same click.
- Checked by hand end to end: one dependent, two dependents, unknown job, that the
  message goes to stderr, and that a successful removal still exits 0 and actually
  removes the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
