### PR TITLE
:bug: Check that a job exists in `Storage.__contains__`

### DIFF
--- a/r3/storage.py
+++ b/r3/storage.py
@@ -49,6 +49,10 @@ class Storage:
     def __contains__(self, job_or_job_id: Union[Job, str]) -> bool:
         """Checks whether a job is in the storage.
 
+        A job is contained if it has an ID, a job with that ID is stored, and the job
+        points at that stored job. The latter matters because `remove` and
+        `checkout_job` use this check to guard operations on `job.path`.
+
         Parameters:
             job_or_job_id: The job or job ID to check for.
         """
@@ -56,8 +60,14 @@ class Storage:
             return (self.root / "jobs" / job_or_job_id).exists()
 
         if isinstance(job_or_job_id, Job):
-            job_path = job_or_job_id.path.resolve()
-            return job_path.parent.parent == self.root
+            if job_or_job_id.id is None:
+                return False
+
+            job_path = self.root / "jobs" / job_or_job_id.id
+            return (
+                job_path.exists()
+                and job_or_job_id.path.resolve() == job_path.resolve()
+            )
 
         raise TypeError(f"Expected Job or str, got {type(job_or_job_id)}")
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -36,19 +36,6 @@ def commit_dependent_job(repository: Repository, job: Job, destination: str) -> 
     return repository.commit(dependent_job)
 
 
-def is_in_repository(repository: Repository, job_id: str) -> bool:
-    """Checks whether a job with the given ID exists in the repository.
-
-    ``job in repository`` only checks whether the job path points into the repository,
-    which stays true after the job has been removed.
-    """
-    try:
-        repository.get_job_by_id(job_id)
-    except KeyError:
-        return False
-    return True
-
-
 def test_remove_removes_job(repository: Repository) -> None:
     job = repository.commit(get_dummy_job("base"))
     assert job.id is not None
@@ -58,7 +45,7 @@ def test_remove_removes_job(repository: Repository) -> None:
     )
 
     assert result.exit_code == 0
-    assert not is_in_repository(repository, job.id)
+    assert job not in repository
 
 
 def test_remove_fails_if_other_jobs_depend_on_job(repository: Repository) -> None:
@@ -77,7 +64,7 @@ def test_remove_fails_if_other_jobs_depend_on_job(repository: Repository) -> Non
     # The dependent must be reported with an explanation, not on its own. The exact
     # wording is asserted in ``test_repository.py``.
     assert len(lines) > 1
-    assert is_in_repository(repository, job.id)
+    assert job in repository
 
 
 def test_remove_fails_if_job_does_not_exist(repository: Repository) -> None:

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -539,6 +539,16 @@ def test_repository_remove_error_message_lists_all_dependents(
     assert_lists_dependents(str(exception_info.value), sorted(dependent_ids))
 
 
+def test_repository_remove_fails_if_job_was_already_removed(
+    repository: Repository
+) -> None:
+    job = repository.commit(get_dummy_job("base"))
+    repository.remove(job)
+
+    with pytest.raises(ValueError):
+        repository.remove(job)
+
+
 def test_find_dependents_requires_job_id(repository: Repository) -> None:
     job = get_dummy_job("base")
     job = repository.commit(job)

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -136,6 +136,34 @@ def test_storage_contains(fs: FakeFilesystem):
     assert committed_job in storage
     assert committed_job.id in storage
 
+    storage.remove(committed_job)
+    assert committed_job not in storage
+    assert committed_job.id not in storage
+
+
+def test_storage_does_not_contain_job_at_a_different_path(fs: FakeFilesystem):
+    """A job is not contained just because a job with the same ID is.
+
+    `Storage.remove` deletes `job.path` once this check passes, so a job pointing
+    somewhere else must not pass it.
+    """
+    fs.create_dir("/repository")
+    storage = Storage.init("/repository")
+
+    committed_job = storage.add(get_dummy_job(fs, "base"))
+    assert committed_job.id is not None
+
+    fs.create_dir("/elsewhere")
+    assert Job("/elsewhere", id=committed_job.id) not in storage
+
+
+def test_storage_does_not_contain_paths_outside_the_jobs_directory(fs: FakeFilesystem):
+    fs.create_dir("/repository")
+    storage = Storage.init("/repository")
+
+    fs.create_dir("/repository/git/some-clone")
+    assert Job("/repository/git/some-clone") not in storage
+
 
 def test_storage_contains_works_with_relative_paths(fs: FakeFilesystem):
     fs.create_dir("/path")


### PR DESCRIPTION
Fixes #58.

For a `Job`, `Storage.__contains__` only asked whether the path sat two levels below
the repository root:

```python
if isinstance(job_or_job_id, Job):
    job_path = job_or_job_id.path.resolve()
    return job_path.parent.parent == self.root
```

It never checked that the job exists, nor that the middle component was `jobs/`, and
so contradicted the `str` branch of the same method, which does check existence.

## Consequences fixed

1. **A removed job still tested as contained**, so `job in repository` and
   `job.id in repository` disagreed about the same job.
2. **`Repository.remove` could not report an already-removed job.** Its
   `if job not in self` guard passed, removal proceeded, and it failed part-way
   through with a `FileNotFoundError` from `_add_write_permission` instead of the
   intended `ValueError("Job is not contained in this repository.")`.
3. **Any path inside the repository passed**, including `<root>/git/<clone>`.

## Why not the fix suggested in the issue

The issue suggested `return job_or_job_id.id in self`. That fixes the reported symptom
but drops a safety property: `remove` and `checkout_job` use this check to guard
operations on `job.path` — `remove` calls `shutil.rmtree(job.path)` immediately after
it. With an ID-only check, a job carrying a valid ID but an unrelated path passes, and
that unrelated path is what gets removed.

Measured across the three candidates:

| Check | committed job | valid ID, foreign path | removed job |
|---|---|---|---|
| before | True | False | **True** (bug 1) |
| `job.id in self` | True | **True** (unsafe) | False |
| this PR | True | False | False |

So the condition is all three: the job has an ID, a job with that ID is stored, and the
job points at that stored job. `test_storage_does_not_contain_job_at_a_different_path`
pins the impostor case, so a later simplification to the ID-only form is caught. That
test passes on `main` too — it is there to stop a regression, not to demonstrate the
bug.

## Tests

- `test_storage_contains` extended: after `storage.remove(...)`, neither the job nor
  its ID is contained.
- `test_storage_does_not_contain_job_at_a_different_path` — the safety property above.
- `test_storage_does_not_contain_paths_outside_the_jobs_directory` — a job pointing at
  `<root>/git/<clone>`.
- `test_repository_remove_fails_if_job_was_already_removed` — `ValueError` rather than a
  part-way `FileNotFoundError`.
- `test/test_cli.py` now says `job in repository` directly; the local helper added in
  #56 to work around this method is removed. That swapped assertion is part of the
  regression guard — it fails against the old behaviour.

## Verification

- `make lint` clean (ruff + mypy); `make test` 175 passed, up from 172.
- Full suite also on Python 3.12 / click 8.2.1 (what `uv.lock` resolves for py3.10+,
  versus click 8.1.8 on py3.9): 175 passed.
- Reverting `__contains__` to the old implementation fails 4 tests, so the new tests
  genuinely pin the behaviour rather than merely passing against the new code.
- Reviewed every caller for fallout — `Index.add`, `Index.update`, `Storage.get`,
  `Storage.remove`, `Storage.checkout_job`, `Repository.remove`,
  `Repository.__contains__` — and checked by hand end to end that commit, checkout,
  find and remove still behave, that a second `remove` and a `checkout` of a removed
  job now report cleanly and exit nonzero, and that `Repository.remove` raises
  `ValueError` for an already-removed job.

Note `Index.__contains__` raises `ValueError` when `job.id is None` where `Storage`
now returns `False`. Left as is — they are separate contracts and nothing depends on
them matching — but worth a look if the two are ever unified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
