### PR TITLE
:label: Add missing return annotations to `Repository` and `Storage`

### DIFF
--- a/r3/repository.py
+++ b/r3/repository.py
@@ -203,11 +203,11 @@ class Repository:
         self._storage.remove(job)
         self._index.remove(job)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Job:
         """Get jobs by their ID with the repository[job_id] syntax."""
         return self.get_job_by_id(key)
 
-    def get_job_by_id(self, job_id: str):
+    def get_job_by_id(self, job_id: str) -> Job:
         """Returns the job with the given ID.
 
         If the job does not exist in the repository it will raise a KeyError.
@@ -248,7 +248,7 @@ class Repository:
         """
         return self._index.find_dependents(job, recursive)
 
-    def rebuild_index(self):
+    def rebuild_index(self) -> None:
         """Rebuilds the job index.
 
         The job index is used to efficiently query for jobs. The index is automatically

--- a/r3/storage.py
+++ b/r3/storage.py
@@ -292,7 +292,7 @@ class Storage:
                     destination / dependency.destination,
                 )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a string representation of the storage."""
         return f"Storage({self.root})"
 


### PR DESCRIPTION
Follow-up to a finding from #59, not a bug fix.

`Repository.get_job_by_id` had a typed argument but no return type:

```python
def get_job_by_id(self, job_id: str):
```

mypy therefore inferred `Any` and stopped checking anything done with the returned job
at the call sites. That is what hid `click.edit` being passed a `Path` where it accepts
`Optional[str]` — the error only appeared once #59 routed the lookup through an
annotated helper, and it is that helper's annotation, rather than anything on
`Repository`, that keeps the call site checked today.

Annotated here:

| | |
|---|---|
| `Repository.get_job_by_id` | `-> Job` |
| `Repository.__getitem__` | `(key: str) -> Job` (delegates to the above) |
| `Repository.rebuild_index` | `-> None` |
| `Storage.__repr__` | `-> str` |

Tightening these surfaces no further errors, which is the thing worth knowing — the
`Any` was masking exactly one real problem, already fixed in #59.

No test accompanies this: the change is annotation-only, so mypy is the check.
`make lint` clean, `make test` 176 passed.

Not included, in case either is wanted: `--disallow-untyped-defs` over `r3/` still
flags 4 spots (`utils.py:35`, `index.py:271`, `cli.py:35`, `cli.py:176`). Clearing
those and enabling the flag in `pyproject.toml` would stop this class of gap
reappearing, but that is a project policy choice rather than part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
