### PR TITLE
:bug: Report a missing or invalid repository instead of crashing

### DIFF
--- a/r3/cli.py
+++ b/r3/cli.py
@@ -3,7 +3,7 @@
 
 import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 import click
 
@@ -19,6 +19,20 @@ import r3
 @click.version_option(r3.__version__, message="%(version)s")
 def cli() -> None:
     pass
+
+
+def _get_repository(repository_path: Optional[Path]) -> r3.Repository:
+    """Returns the repository at the given path, reporting problems to the user."""
+    if repository_path is None:
+        raise click.UsageError(
+            "No repository given. Use --repository or set the R3_REPOSITORY "
+            "environment variable."
+        )
+
+    try:
+        return r3.Repository(repository_path)
+    except (FileNotFoundError, NotADirectoryError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
 
 
 def _get_job(repository: r3.Repository, job_id: str) -> r3.Job:
@@ -52,8 +66,9 @@ def init(path: Path):
     "repository_path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     envvar="R3_REPOSITORY",
+    show_envvar=True,
 )
-def commit(path: Path, repository_path: Path) -> None:
+def commit(path: Path, repository_path: Optional[Path]) -> None:
     """Adds the job at PATH to the repository.
 
     This command resolves all dependencies of the job and copies the job files to the R3
@@ -69,7 +84,7 @@ def commit(path: Path, repository_path: Path) -> None:
     4b2146f3-5594-4f05-ae13-2e053ef7bfda
     ```
     """
-    repository = r3.Repository(repository_path)
+    repository = _get_repository(repository_path)
     job = r3.Job(path)
     job = repository.commit(job)
     print(job.id)
@@ -83,8 +98,9 @@ def commit(path: Path, repository_path: Path) -> None:
     "repository_path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     envvar="R3_REPOSITORY",
+    show_envvar=True,
 )
-def checkout(job_id: str, target_path: Path, repository_path: Path) -> None:
+def checkout(job_id: str, target_path: Path, repository_path: Optional[Path]) -> None:
     """Checks out the job with JOB_ID to TARGET_PATH.
 
     This copies all job files from JOB_PATH in the R3 repository to the TARGET_PATH.
@@ -101,7 +117,7 @@ def checkout(job_id: str, target_path: Path, repository_path: Path) -> None:
     output/ -> /repository/jobs/4b2146f3-5594-4f05-ae13-2e053ef7bfda/output
     ```
     """
-    repository = r3.Repository(repository_path)
+    repository = _get_repository(repository_path)
     job = _get_job(repository, job_id)
     repository.checkout(job, target_path)
 
@@ -113,13 +129,14 @@ def checkout(job_id: str, target_path: Path, repository_path: Path) -> None:
     "repository_path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     envvar="R3_REPOSITORY",
+    show_envvar=True,
 )
-def remove(job_id: str, repository_path: Path) -> None:
+def remove(job_id: str, repository_path: Optional[Path]) -> None:
     """Removes the job with JOB_ID from the R3 repository.
 
     If any other job in the R3 repository depends on the job, removing it will fail.
     """
-    repository = r3.Repository(repository_path)
+    repository = _get_repository(repository_path)
     job = _get_job(repository, job_id)
 
     try:
@@ -151,10 +168,13 @@ def remove(job_id: str, repository_path: Path) -> None:
     "repository_path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     envvar="R3_REPOSITORY",
+    show_envvar=True,
 )
-def find(tags: Iterable[str], latest: bool, long: bool, repository_path: Path) -> None:
+def find(
+    tags: Iterable[str], latest: bool, long: bool, repository_path: Optional[Path]
+) -> None:
     """Searches the R3 repository for jobs matching the given conditions."""
-    repository = r3.Repository(repository_path)
+    repository = _get_repository(repository_path)
     query = {"tags": {"$all": tags}}
     for job in repository.find(query, latest):
         if long:
@@ -172,15 +192,16 @@ def find(tags: Iterable[str], latest: bool, long: bool, repository_path: Path) -
     "repository_path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     envvar="R3_REPOSITORY",
+    show_envvar=True,
 )
-def rebuild_index(repository_path: Path):
+def rebuild_index(repository_path: Optional[Path]):
     """Rebuild the search index.
     
     The index is used when querying for jobs. All R3 commands properly update the index.
     When job metadata is modified manually, however, the index needs to be rebuilt in
     order for the changes to take effect.
     """
-    repository = r3.Repository(repository_path)
+    repository = _get_repository(repository_path)
     repository.rebuild_index()
 
 
@@ -193,10 +214,11 @@ def rebuild_index(repository_path: Path):
     "repository_path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     envvar="R3_REPOSITORY",
+    show_envvar=True,
 )
-def edit(job_id: str, repository_path: Path) -> None:
+def edit(job_id: str, repository_path: Optional[Path]) -> None:
     """Edit a jobs metadata."""
-    repository = r3.Repository(repository_path)
+    repository = _get_repository(repository_path)
     job = _get_job(repository, job_id)
 
     # Let user edit the metadata file of the job

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,6 +1,7 @@
 """Unit tests for the R3 command line interface."""
 
 from pathlib import Path
+from typing import List
 
 import pytest
 import yaml
@@ -154,3 +155,75 @@ def test_checkout_fails_if_job_does_not_exist(
     # ``str(KeyError(...))`` is a repr and would wrap the whole message in quotes.
     assert "Error: '" not in result.output
     assert not target_path.exists()
+
+
+def commands_taking_a_repository(tmp_path: Path) -> List[List[str]]:
+    """Returns a minimal invocation of every command that takes a repository.
+
+    The path arguments must exist, so that click's own validation passes and the command
+    body is actually reached.
+    """
+    job_path = tmp_path / "job"
+    job_path.mkdir(exist_ok=True)
+    job_id = "00000000-0000-0000-0000-000000000000"
+
+    return [
+        ["find"],
+        ["rebuild-index"],
+        ["remove", job_id],
+        ["edit", job_id],
+        ["checkout", job_id, str(tmp_path / "target")],
+        ["commit", str(job_path)],
+    ]
+
+
+def test_commands_report_a_missing_repository(tmp_path: Path) -> None:
+    # Looped rather than parametrized, since the commands need `tmp_path`.
+    for command in commands_taking_a_repository(tmp_path):
+        result = CliRunner().invoke(cli, command, env={"R3_REPOSITORY": None})
+
+        assert result.exit_code != 0, command
+        # Reported, not raised as an unhandled exception.
+        assert (
+            result.exception is None or isinstance(result.exception, SystemExit)
+        ), command
+        # Whichever way the user meant to pass it, name it.
+        assert "--repository" in result.output, command
+        assert "R3_REPOSITORY" in result.output, command
+
+
+def test_commands_report_an_empty_repository_env_var() -> None:
+    result = CliRunner().invoke(cli, ["find"], env={"R3_REPOSITORY": ""})
+
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "R3_REPOSITORY" in result.output
+
+
+def test_commands_report_a_path_that_is_not_a_repository(tmp_path: Path) -> None:
+    not_a_repository = tmp_path / "not-a-repository"
+    not_a_repository.mkdir()
+
+    result = CliRunner().invoke(cli, ["find", "--repository", str(not_a_repository)])
+
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert str(not_a_repository) in result.output
+
+
+def test_commands_report_an_outdated_repository_version(repository: Repository) -> None:
+    with open(repository.path / "r3.yaml", "w") as config_file:
+        yaml.dump({"version": "1.0.0-beta.1"}, config_file)
+
+    result = CliRunner().invoke(cli, ["find", "--repository", str(repository.path)])
+
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "1.0.0-beta.1" in result.output
+
+
+def test_help_mentions_the_repository_env_var() -> None:
+    result = CliRunner().invoke(cli, ["find", "--help"])
+
+    assert result.exit_code == 0
+    assert "R3_REPOSITORY" in result.output


### PR DESCRIPTION
Fixes #63.

`--repository` declares `envvar="R3_REPOSITORY"` but is not `required` and has no
default, so with neither set `repository_path` was `None` and `Repository.__init__`
called `Path(None)`. All six commands taking a repository failed with a `pathlib`
traceback naming neither the option nor the variable — so the actual mistake was not
discoverable from the output.

While confirming it, two related cases turned out to share the gap: `Repository.__init__`
also raises `ValueError` for a directory that is not a repository and for an outdated
format version, and neither was handled either.

| `--repository` / `R3_REPOSITORY` | Before | After |
|---|---|---|
| unset | `TypeError: ... not NoneType` traceback, exit 1 | `Error: No repository given. Use --repository or set the R3_REPOSITORY environment variable.` exit 2 |
| empty string | same traceback, exit 1 | same as unset, exit 2 |
| not a repository | `ValueError: Invalid repository: <path>` traceback, exit 1 | `Error: Invalid repository: <path>` exit 1 |
| outdated version | `ValueError: Invalid repository version: ...` traceback, exit 1 | `Error: Invalid repository version: 1.0.0-beta.1. Please migrate to 1.0.0-beta.7.` exit 1 |
| nonexistent path | already a clean click error | unchanged |
| a file, not a directory | already a clean click error | unchanged |

The outdated-version row is the one I would highlight: that message was always helpful —
it tells you to migrate — but inside a traceback it read as a crash rather than an
instruction, and anyone upgrading r3 against an existing repository meets it.

Empty string matters because click treats an empty environment variable as absent, so
`export R3_REPOSITORY=` in a sourced profile reproduced the original crash by a
different route. There is a test pinning it.

## Implementation

A `_get_repository` helper next to the existing `_get_job`, used by all six commands
(`commit`, `checkout`, `remove`, `find`, `rebuild-index`, `edit`):

- missing → `click.UsageError` naming **both** the option and the environment variable,
  so whichever the user intended is mentioned. Exit 2, matching click's convention for a
  missing option.
- not a repository / outdated version → `click.ClickException` carrying `Repository`'s
  own message. Exit 1, since the path was supplied correctly; the problem is what it
  points at.

`required=True` was considered and rejected: it yields `Error: Missing option
'--repository'.`, which never mentions `R3_REPOSITORY` — the thing actually forgotten —
and does nothing for the other two rows.

Also `show_envvar=True`, so `r3 <command> --help` now shows:

```
  --repository DIRECTORY  [env var: R3_REPOSITORY]
```

The parameter is now typed `Optional[Path]`, which is what it always was in practice.

## Tests

`test/test_cli.py` gains five tests, all of which fail against the previous code:

- every one of the six commands reports a missing repository, naming both the option and
  the variable. Written as a loop over the commands rather than `parametrize` because the
  invocations need `tmp_path`; the intent is that a future command cannot quietly skip
  the helper.
- an empty `R3_REPOSITORY` is treated as unset.
- a directory that is not a repository, and an outdated format version, are both reported
  rather than raised — asserted via `result.exception is None or isinstance(result.exception,
  SystemExit)`, which is what distinguishes a reported error from a crash under `CliRunner`.
- `--help` mentions the variable.

`r3/cli.py` coverage 73% → 79%.

## Verification

- `make lint` clean (ruff + mypy); `make test` 181 passed, up from 176.
- Full suite also on Python 3.12 / click 8.2.1: 181 passed.
- Checked by hand end to end: all six commands with the variable unset, plus the empty,
  not-a-repository and outdated-version cases, and that a valid repository still commits
  and finds normally.

Not included: the `--repository` option block is now declared six times identically, and
all six needed the same edit here. Factoring it into a shared decorator would remove that
drift risk, but it is a structural change rather than part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
