### PR TITLE
:construction_worker: Run pytest in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: lint
+name: CI
 
 on:
   pull_request:
@@ -35,3 +35,22 @@ jobs:
 
       - name: Run mypy
         run: uv run mypy r3 test migration
+
+
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 gets the full history: a git-dependency test clones this
+      # repo and checks out an old commit, which the default shallow clone omits.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Run tests
+        run: uv run python -m pytest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest fixtures for the R3 test suite."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give every test a self-contained git identity, independent of the machine.
+
+    Also nulls ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` so machine-local settings
+    (e.g. ``commit.gpgsign``) can't make ``git commit`` fail regardless of identity.
+    """
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "R3 Test")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "R3 Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "r3-test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "r3-test@example.com")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", "/dev/null")


### PR DESCRIPTION
## What

Adds a `pytest` job to CI (`.github/workflows/main.yaml`), which currently runs only `ruff` and `mypy`, and a shared `test/conftest.py` git-identity fixture that the test job needs. Also renames the workflow `lint` → `CI`, since it now runs tests, not just linters (job names are unchanged, so any required-status-check rules are unaffected).

## Why the two pieces are required together

Both needs are driven by **pre-existing tests**, not by anything new here:

- **`fetch-depth: 0`** on the checkout — `test/test_storage.py::test_checkout_git_dependency_clones_repository` clones this repository and checks out an old commit (`c2397aa`, 2024-02-20). The default shallow `actions/checkout` clone omits that object, so the test would fail without full history.
- **`test/conftest.py` identity fixture** — the `ExampleGitRepository` tests in `test/test_repository.py` run real `git commit`, which fails with "Author identity unknown" on a bare CI runner. The autouse fixture supplies `GIT_AUTHOR_*`/`GIT_COMMITTER_*`. It also nulls `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` — not for identity (the env vars already win there) but to neutralize machine-local settings such as `commit.gpgsign`, which otherwise make `git commit` fail regardless of identity. Nulling them also makes a local run reproduce the bare-CI state, so a green local run genuinely proves the CI fix.

## Verification

- `uv run python -m pytest` → **181 passed** (plain clone).
- `uv run ruff check r3 test` → clean.
- `uv run mypy r3 test migration` → no issues.

## Notes

- `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are no-ops on git < 2.32 (2021); the local-reproduces-CI guarantee silently weakens there. Low real-world risk; noted only.

---

First of a short series factoring general-purpose changes out of the large `feature/remote-storage` branch into small, independent PRs. This one lands first so the later PRs get real test coverage in CI.
