### PR TITLE
:bug: Roll back Index Transaction when the with-block raises

### DIFF
--- a/r3/index.py
+++ b/r3/index.py
@@ -269,5 +269,10 @@ class Transaction:
         return self.cursor
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        self.connection.commit()
-        self.connection.close()
+        try:
+            if exc_type is None:
+                self.connection.commit()
+            else:
+                self.connection.rollback()
+        finally:
+            self.connection.close()

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 import pytest
 import yaml
 
-from r3.index import Index
+from r3.index import Index, Transaction
 from r3.job import Job, JobDependency
 from r3.storage import Storage
 
@@ -262,3 +262,32 @@ def test_index_find_dependents_uses_cached_metadata(storage_with_jobs: Storage):
     job = index.find({"tags": {"$all": ["test-again"]}}, latest=True)[0]
     dependents = index.find_dependents(job)
     assert all(dependent.uses_cached_metadata() for dependent in dependents)
+
+
+def test_transaction_rolls_back_on_exception(storage: Storage):
+    """A Transaction that raises mid-block must not persist its writes."""
+    # Bootstrap the schema via Index (its __init__ rebuilds an absent index),
+    # then talk to the raw Transaction directly.
+    index = Index(storage)
+    path = storage.root / "index.sqlite"
+    del index
+
+    class _BoomError(Exception):
+        pass
+
+    # A write followed by a raise inside the block: the exception must
+    # propagate and the write must not be committed.
+    with pytest.raises(_BoomError):
+        with Transaction(path) as cursor:
+            cursor.execute(
+                "INSERT INTO jobs (id, timestamp, metadata) VALUES (?, ?, ?)",
+                ("rollback-sentinel", "2021-01-01T00:00:00", "{}"),
+            )
+            raise _BoomError
+
+    # A fresh connection must not see the rolled-back row.
+    with Transaction(path) as cursor:
+        cursor.execute(
+            "SELECT COUNT(*) FROM jobs WHERE id = ?", ("rollback-sentinel",)
+        )
+        assert cursor.fetchone()[0] == 0


### PR DESCRIPTION
Closes #66.

## What

`Transaction.__exit__` (`r3/index.py`) committed unconditionally, so an exception raised inside a `with Transaction(...)` block still committed whatever had already been written. The atomicity the wrapper is meant to provide didn't hold, and a failed index operation could leave the index partially written.

Now it commits only on a clean exit, rolls back on an exception, and closes the connection in a `finally` on both paths:

```python
def __exit__(self, exc_type, exc_value, traceback) -> None:
    try:
        if exc_type is None:
            self.connection.commit()
        else:
            self.connection.rollback()
    finally:
        self.connection.close()
```

## Test

`test/test_index.py::test_transaction_rolls_back_on_exception` writes a sentinel row, raises inside the block, then opens a fresh connection and asserts the row isn't there. Verified RED on the old code (`assert 1 == 0`) and GREEN after the fix.

## Verification

- `uv run python -m pytest` → 181 passed
- `uv run ruff check r3 test` → clean
- `uv run mypy r3 test migration` → no issues

---

Second in the series factoring general-purpose changes out of the large `feature/remote-storage` branch into small, independent PRs.
