### PR TITLE
:lock: Validate job ids before joining them onto the jobs/ path

### DIFF
--- a/r3/repository.py
+++ b/r3/repository.py
@@ -220,7 +220,7 @@ class Repository:
         """
         try:
             return self._storage.get(job_id=job_id)
-        except FileNotFoundError as error:
+        except (FileNotFoundError, ValueError) as error:
             message = f"Job with ID {job_id} not found in this repository."
             raise KeyError(message) from error
 

--- a/r3/storage.py
+++ b/r3/storage.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Iterator, Optional, Union
 import yaml
 from executor import execute
 
+import r3.utils
 from r3.job import Dependency, GitDependency, Job, JobDependency
 
 
@@ -53,11 +54,14 @@ class Storage:
         points at that stored job. The latter matters because `remove` and
         `checkout_job` use this check to guard operations on `job.path`.
 
+        A non-canonical id string raises ``ValueError`` (see ``_job_path``) rather
+        than returning ``False``.
+
         Parameters:
             job_or_job_id: The job or job ID to check for.
         """
         if isinstance(job_or_job_id, str):
-            return (self.root / "jobs" / job_or_job_id).exists()
+            return self._job_path(job_or_job_id).exists()
 
         if isinstance(job_or_job_id, Job):
             if job_or_job_id.id is None:
@@ -70,6 +74,16 @@ class Storage:
             )
 
         raise TypeError(f"Expected Job or str, got {type(job_or_job_id)}")
+
+    def _job_path(self, job_id: str) -> Path:
+        """Validates ``job_id`` and returns its path under ``jobs/``.
+
+        The single choke point where a job id becomes a ``jobs/`` path. Validating
+        here refuses a non-canonical id — path traversal, glob, separators — before it
+        is ever joined onto the storage root.
+        """
+        r3.utils.validate_job_id(job_id)
+        return self.root / "jobs" / job_id
 
     def get(
         self,
@@ -89,11 +103,12 @@ class Storage:
         Returns:
             The job with the given ID.
         """
-        if job_id not in self:
+        job_path = self._job_path(job_id)
+        if not job_path.exists():
             raise FileNotFoundError(f"Job not found: {job_id}")
 
         return Job(
-            self.root / "jobs" / job_id,
+            job_path,
             job_id,
             cached_timestamp=cached_timestamp,
             cached_metadata=cached_metadata,
@@ -241,7 +256,7 @@ class Storage:
             self.checkout_job(job, destination)
             return
 
-        source = self.root / "jobs" / dependency.job / dependency.source
+        source = self._job_path(dependency.job) / dependency.source
 
         os.makedirs(destination.parent, exist_ok=True)
         os.symlink(source, destination)

--- a/r3/utils.py
+++ b/r3/utils.py
@@ -1,8 +1,28 @@
 import hashlib
+import uuid
 from pathlib import Path
 from typing import Iterable, List, Optional
 
 from executor import ExternalCommandFailed, execute
+
+
+def is_valid_job_id(job_id: object) -> bool:
+    """Returns whether ``job_id`` is a canonical UUID string (as produced by uuid4)."""
+    try:
+        return isinstance(job_id, str) and str(uuid.UUID(job_id)) == job_id
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def validate_job_id(job_id: object) -> None:
+    """Raises ``ValueError`` unless ``job_id`` is a canonical UUID string.
+
+    Call this at every boundary that turns an id into a filesystem path, before the
+    path is built. ``ValueError`` (rather than a bespoke type) is deliberate: the CLI
+    already funnels these into clean user-facing errors.
+    """
+    if not is_valid_job_id(job_id):
+        raise ValueError(f"Invalid job id: {job_id!r}")
 
 
 def find_files(path: Path, ignore_patterns: Iterable[str]) -> List[Path]:

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -199,7 +199,7 @@ def test_storage_get_raises_if_job_id_does_not_exist(fs: FakeFilesystem):
     storage = Storage.init("/repository")
 
     with pytest.raises(FileNotFoundError):
-        storage.get("non-existent")
+        storage.get("00000000-0000-4000-8000-00000000dead")
 
 
 def test_storage_get_raises_if_job_does_not_exist(fs: FakeFilesystem):
@@ -207,7 +207,7 @@ def test_storage_get_raises_if_job_does_not_exist(fs: FakeFilesystem):
     storage = Storage.init("/repository")
 
     with pytest.raises(FileNotFoundError):
-        storage.get("non-existent")
+        storage.get("00000000-0000-4000-8000-00000000dead")
 
 
 def test_storage_jobs_returns_all_jobs(fs: FakeFilesystem):
@@ -486,3 +486,19 @@ def test_checkout_git_dependency_clones_repository():
             expected_content_path / "test" / "test_storage.py",
             checkout_path / "destination",
         )
+
+
+def test_storage_get_rejects_non_canonical_id(fs: FakeFilesystem):
+    fs.create_dir("/repository")
+    storage = Storage.init("/repository")
+
+    with pytest.raises(ValueError):
+        storage.get("../../escaped")
+
+
+def test_checkout_job_dependency_rejects_non_canonical_id(fs: FakeFilesystem):
+    fs.create_dir("/repository")
+    storage = Storage.init("/repository")
+    dependency = JobDependency("destination", "../../escaped", "source")
+    with pytest.raises(ValueError):
+        storage.checkout_job_dependency(dependency, Path("/checkout"))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,9 @@
 """Unit tests for ``r3.utils``."""
 
+import uuid
 from pathlib import Path
 
+import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 import r3.utils
@@ -24,3 +26,49 @@ def test_find_files_ignores_sibling_dirs_after_recursing_into_earlier_sibling(
     files = r3.utils.find_files(Path("/job"), ["/cache"])
 
     assert Path("cache/big_file.bin") not in files
+
+
+def test_is_valid_job_id_accepts_canonical_uuids() -> None:
+    for _ in range(50):
+        job_id = str(uuid.uuid4())
+        assert r3.utils.is_valid_job_id(job_id)
+    # The nil UUID is canonical too.
+    assert r3.utils.is_valid_job_id("00000000-0000-0000-0000-000000000000")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "../../victim",                       # relative traversal
+        "..",                                 # bare parent ref
+        "/etc/passwd",                        # absolute path
+        "a/b",                                # path separator
+        "jobs\\evil",                         # backslash separator
+        "job-*",                              # glob metacharacter
+        "job?",                               # glob metacharacter
+        "job[a-z]",                           # glob metacharacter
+        "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",  # uppercase (non-canonical)
+        "{00000000-0000-4000-8000-000000000000}",  # braces
+        "urn:uuid:00000000-0000-4000-8000-000000000000",  # urn form
+        "00000000000040008000000000000000",   # hex without hyphens (non-canonical)
+        "not-a-uuid",
+        "",
+        "   ",
+    ],
+)
+def test_is_valid_job_id_rejects_non_canonical(bad: str) -> None:
+    assert not r3.utils.is_valid_job_id(bad)
+
+
+@pytest.mark.parametrize("bad", [None, 123, 1.0, b"bytes", uuid.uuid4(), ["x"]])
+def test_is_valid_job_id_rejects_non_str(bad: object) -> None:
+    assert not r3.utils.is_valid_job_id(bad)
+
+
+def test_validate_job_id_passes_for_canonical() -> None:
+    r3.utils.validate_job_id(str(uuid.uuid4()))  # no raise
+
+
+def test_validate_job_id_raises_for_non_canonical() -> None:
+    with pytest.raises(ValueError):
+        r3.utils.validate_job_id("../../escaped")


### PR DESCRIPTION
Closes #68.

## What

`Storage` joined a caller-supplied job-id string straight onto the `jobs/` path with no validation, so a non-canonical id (`../..`, an absolute path, glob metacharacters) reached the filesystem. This refuses a non-canonical id at the single point where an id becomes a `jobs/` path.

- `r3/utils.py`: `is_valid_job_id` / `validate_job_id` — a canonical-UUID round-trip (`str(uuid.UUID(x)) == x`). Job ids are only ever produced as `str(uuid.uuid4())`, so anything else is illegitimate.
- `r3/storage.py`: a single `_job_path(job_id)` choke point validates then builds the path. `get` (directly), the `str in storage` check, and `checkout_job_dependency` all route through it.
- `r3/repository.py`: `get_job_by_id` now maps the new `ValueError` to `KeyError` too, preserving its documented contract (a bad id → `KeyError`, so `_get_job` in the CLI still reports it cleanly).

## Tests

- `test/test_utils.py`: validator accepts canonical UUIDs (incl. nil), rejects traversal / absolute / separator / glob / uppercase / braced / urn / non-str forms.
- `test/test_storage.py`: `get` and `checkout_job_dependency` reject a non-canonical id (`ValueError`); the two existing not-found cases now use a canonical-but-absent UUID.

## Verification

- `uv run python -m pytest` → all pass
- `uv run ruff check r3 test` → clean
- `uv run mypy r3 test migration` → no issues

## Scope note

This closes the `Storage` path-join vector (#68). A separate, pre-existing path-join in `Repository.__contains__` (a dependency's `job` field from `r3.yaml`) is a distinct vector and will be handled in its own issue/PR.

---

Third in the series factoring general-purpose changes out of the large `feature/remote-storage` branch into small, independent PRs.
