### PR TITLE
:lock: Validate a dependency's job id in Repository.__contains__

### DIFF
--- a/r3/repository.py
+++ b/r3/repository.py
@@ -114,6 +114,8 @@ class Repository:
             return all(dependency in self for dependency in resolved_item)
 
         if isinstance(resolved_item, JobDependency):
+            if not r3.utils.is_valid_job_id(resolved_item.job):
+                return False
             target = self.path / "jobs" / resolved_item.job / resolved_item.source
             return target.exists()
 

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -854,3 +854,13 @@ def test_repository_get_job_by_id(repository: Repository) -> None:
         repository.get_job_by_id("invalid-job-id")
     with pytest.raises(KeyError):
         repository["invalid-job-id"]
+
+
+def test_repository_does_not_contain_dependency_with_non_canonical_job_id(
+    repository: Repository,
+) -> None:
+    # A dependency whose job id escapes jobs/ and points back at an existing file:
+    # the raw join would report it as contained, so it must be rejected as invalid.
+    (repository.path / "marker").write_text("x")
+    dependency = JobDependency(destination="d", job="..", source="marker")
+    assert dependency not in repository


### PR DESCRIPTION
Closes #70.

## What

`Repository.__contains__`'s `JobDependency` branch joined a dependency's `job` field — which comes unvalidated from `r3.yaml` — straight onto the `jobs/` path. A non-canonical value (e.g. `".."`) escaped `jobs/`, and `.exists()` could even report the dependency as contained. This rejects a non-canonical dependency job id as not-contained, reusing `is_valid_job_id` (added in #69):

```python
if isinstance(resolved_item, JobDependency):
    if not r3.utils.is_valid_job_id(resolved_item.job):
        return False
    target = self.path / "jobs" / resolved_item.job / resolved_item.source
    return target.exists()
```

This closes the last unvalidated `jobs/`-join after #68/#69. Not exploitable in today's single-owner use (anyone who can commit an `r3.yaml` can already run code), but a malformed dependency should plainly be invalid, and this forecloses a path-traversal/info-leak if repositories ever accept job definitions from a less-trusted source.

## Test

`test/test_repository.py::test_repository_does_not_contain_dependency_with_non_canonical_job_id` — a dependency whose `job` (`..`) escapes `jobs/` to an existing file is reported as not-contained (RED before the guard, GREEN after).

## Verification

- `uv run python -m pytest` → all pass
- `uv run ruff check r3 test` → clean
- `uv run mypy r3 test migration` → no issues
