### PR TITLE
:memo: Add LIMITATIONS and ROADMAP

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,60 @@
+# Known Limitations
+
+Sharp edges and intentional scope limits in R3, in one visible place. Each entry
+says what it means in practice. Read this before relying on R3 for anything you
+can't afford to lose, and before pointing multiple processes or people at one
+repository.
+
+---
+
+## No concurrency control (single writer per repository)
+
+R3 assumes one mutating process per repository at a time. Running mutating commands
+concurrently — two `r3 commit`s, or `rebuild-index` overlapping a `commit`/`remove`
+— is unsupported and can corrupt the index, so treat single-writer as a hard rule.
+The index is disposable: `r3 rebuild-index` rebuilds it from the jobs on disk.
+(Enforced locking is unscheduled — `flock` is unreliable on the network filesystems
+R3 often runs on.)
+
+---
+
+## Durability is against process interruption, not power loss
+
+R3 operations are safe to interrupt (crash, `Ctrl-C`, kill) and re-run, but are not
+yet durable across a host power loss mid-operation: just-written files and their
+parent directories are not `fsync`-ed, so a power cut can lose a just-written file or
+leave a partial one. The exposed surface is small — SQLite commits are `fsync`-durable
+and the index is rebuildable, so the risk is the transient local copy steps,
+recoverable by re-running the command (and `r3 rebuild-index`). After an unclean
+shutdown mid-operation, re-run the interrupted command. Adding explicit `fsync` at
+commit points is on the [roadmap](ROADMAP.md).
+
+---
+
+## Empty directories are not preserved
+
+A job's file set is a list of files, so empty directories are not represented (except
+the conventional `output/`, which is always present). Don't depend on an otherwise-empty
+directory — make sure any directory you depend on holds at least one file.
+
+---
+
+## Symlinks and special files are not supported
+
+R3 stores regular files only and does not preserve symbolic links. At commit, a file
+symlink is silently dereferenced (its target's content is stored as a plain file), a
+directory symlink is followed and flattened into the job, and a broken symlink is
+silently dropped — the link itself is never kept. Keep job directories to regular
+files, materializing anything reached through a symlink before committing. Making
+commit fail closed on symlinks/special files, and eventually preserving them properly,
+are on the [roadmap](ROADMAP.md).
+
+---
+
+## `r3.yaml` is managed by R3 — don't hand-format it
+
+`r3.yaml` is an R3-managed file: `r3 init` and format migrations rewrite it by
+re-serializing the parsed config, which does not preserve comments, blank lines, or key
+order. Don't rely on hand-formatting there — it's lost on the next rewrite; keep notes
+about your setup elsewhere. Round-tripping through a comment-aware YAML library is a
+possible future improvement (see [ROADMAP.md](ROADMAP.md)).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,25 @@
+# Roadmap
+
+Non-binding future directions for R3 — not commitments or a schedule. For the
+*current* sharp edges and scope limits, see [LIMITATIONS.md](LIMITATIONS.md).
+
+## Future directions
+
+- **Preserve comments/formatting in `r3.yaml`.** Round-trip the config through a
+  comment-aware YAML library (`ruamel.yaml`) so migrations and future config writes
+  keep comments, blank lines, and key order — deferred to avoid a new dependency for
+  now.
+- **Fail closed on symlinks/special files at commit.** `commit` currently handles
+  symlinks silently — it dereferences a file symlink (storing the target's content),
+  follows and flattens a directory symlink, and drops a broken symlink. A near-term
+  guard should make `commit` refuse a job containing any symlink or special file
+  (FIFO/socket/device) with a clear error, so nothing is silently altered or lost.
+- **Proper symlink support.** Preserve symbolic links as links through commit and
+  checkout, rather than dereferencing or dropping them. Started on the unmerged
+  `feat-symlinks` branch.
+- **Power-loss durability (`fsync`).** The current crash model covers process
+  interruption, not power loss.
+- **Python 3.13 support.** Blocked on the `executor` dependency, which imports the
+  `pipes` stdlib module (removed in 3.13) at import time, so r3 can't be imported on
+  3.13 at all. r3's own code is 3.13-clean; unblocking needs a 3.13-compatible
+  `executor` release (23.2 still imports `pipes`) or replacing that dependency.


### PR DESCRIPTION
## What

Adds two root docs:

- **`LIMITATIONS.md`** — R3's current sharp edges and intentional scope limits: single-writer (no concurrency control), durability against process interruption but not power loss (no `fsync`), empty directories not preserved, symlink/special-file handling at commit, and `r3.yaml` being R3-managed.
- **`ROADMAP.md`** — non-binding future directions (comment-preserving `r3.yaml`, fail-closed symlinks at commit, proper symlink support, power-loss `fsync`, Python 3.13).

## Verification

Every behavior documented was checked against the code:

- Symlink handling at commit — `r3/utils.py` `_find_files` (`is_file()`/`is_dir()` follow symlinks; a broken symlink matches neither and is dropped) + `Storage.add`'s `shutil.copy`.
- Empty dirs — `_find_files` only yields files; `output/` is always created by `add`.
- `r3.yaml` rewrite — `Repository.init` and the format migrations re-serialize the config.
- Single-writer / no `fsync` — no locking primitives or `fsync` in the commit/remove/rebuild paths.

Both files live at the repo root (outside `docs/`), so they aren't in the mkdocs nav; `mkdocs build --strict` builds clean with no `mkdocs.yml` change.

---

Last in the series factoring general-purpose content out of the large `feature/remote-storage` branch into small, independent PRs.
