### PR TITLE
:bug: Order `find` results oldest-first by timestamp

### DIFF
--- a/r3/cli.py
+++ b/r3/cli.py
@@ -173,7 +173,10 @@ def remove(job_id: str, repository_path: Optional[Path]) -> None:
 def find(
     tags: Iterable[str], latest: bool, long: bool, repository_path: Optional[Path]
 ) -> None:
-    """Searches the R3 repository for jobs matching the given conditions."""
+    """Searches the R3 repository for jobs matching the given conditions.
+
+    Results are listed oldest-first by timestamp.
+    """
     repository = _get_repository(repository_path)
     query = {"tags": {"$all": tags}}
     for job in repository.find(query, latest):

--- a/r3/index.py
+++ b/r3/index.py
@@ -200,11 +200,15 @@ class Index:
             latest: Whether to return the latest job or all jobs with the given tags.
 
         Returns:
-            The jobs that match the given query.
+            The jobs that match the given query, ordered oldest-first by timestamp,
+            ties broken by job id. When `latest` is set, only the single most recent
+            job is returned.
         """
         sql_query = f"SELECT id, timestamp, metadata FROM jobs WHERE {mongo_to_sql(query)}"  # noqa: E501
         if latest:
-            sql_query += " ORDER BY timestamp DESC LIMIT 1"
+            sql_query += " ORDER BY timestamp DESC, id DESC LIMIT 1"
+        else:
+            sql_query += " ORDER BY timestamp ASC, id ASC"
 
         with Transaction(self._path) as transaction:
             transaction.execute(sql_query)

--- a/r3/repository.py
+++ b/r3/repository.py
@@ -232,7 +232,9 @@ class Repository:
             latest: Whether to return the latest job or all jobs with the given tags.
 
         Returns:
-            The jobs that match the given tags.
+            The jobs that match the given tags, ordered oldest-first by timestamp
+            (ties broken by job id). When `latest` is set, only the single most
+            recent job is returned.
         """
         return self._index.find(query, latest)
 

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -182,6 +182,69 @@ def test_index_find(storage_with_jobs: Storage):
     assert set(result.id for result in results) == {job1.id, job2.id}
 
 
+def _with_timestamp(job: Job, timestamp: datetime.datetime) -> Job:
+    """Re-wraps a committed job with an explicit cached timestamp."""
+    return Job(job.path, job.id, cached_timestamp=timestamp)
+
+
+def test_index_find_orders_by_timestamp(storage: Storage):
+    """`find` returns jobs oldest-first, independent of insertion order."""
+    index = Index(storage)
+
+    early, middle, late = (storage.add(get_dummy_job("base")) for _ in range(3))
+
+    # Assign explicit, non-chronological timestamps and insert into the index in an
+    # order that does not match timestamp order. The result can only come out sorted
+    # if `find` orders by timestamp rather than by insertion (rowid) order.
+    index.add(_with_timestamp(middle, datetime.datetime(2021, 1, 2)))
+    index.add(_with_timestamp(late, datetime.datetime(2021, 1, 3)))
+    index.add(_with_timestamp(early, datetime.datetime(2021, 1, 1)))
+
+    results = index.find({})
+
+    assert [job.timestamp for job in results] == [
+        datetime.datetime(2021, 1, 1),
+        datetime.datetime(2021, 1, 2),
+        datetime.datetime(2021, 1, 3),
+    ]
+
+
+def test_index_find_breaks_timestamp_ties_by_id(storage: Storage):
+    """Identical timestamps are ordered deterministically by job id."""
+    index = Index(storage)
+    timestamp = datetime.datetime(2021, 1, 1)
+
+    jobs = [storage.add(get_dummy_job("base")) for _ in range(4)]
+    by_id = sorted(jobs, key=lambda job: str(job.id))
+
+    # Insert id-descending so a correct (id-ascending) result cannot come from
+    # insertion order.
+    for job in reversed(by_id):
+        index.add(_with_timestamp(job, timestamp))
+
+    results = index.find({})
+
+    assert [job.id for job in results] == [job.id for job in by_id]
+
+
+def test_index_find_latest_breaks_timestamp_ties_by_id(storage: Storage):
+    """`latest` resolves timestamp ties deterministically by job id."""
+    index = Index(storage)
+    timestamp = datetime.datetime(2021, 1, 1)
+
+    jobs = [storage.add(get_dummy_job("base")) for _ in range(4)]
+    by_id = sorted(jobs, key=lambda job: str(job.id))
+
+    # Insert id-ascending so the largest id is not simply the first inserted.
+    for job in by_id:
+        index.add(_with_timestamp(job, timestamp))
+
+    results = index.find({}, latest=True)
+
+    assert len(results) == 1
+    assert results[0].id == by_id[-1].id
+
+
 @pytest.mark.parametrize(
     "tags,expected",
     [


### PR DESCRIPTION
## Problem (closes #60)

`Repository.find` / `Index.find` add an `ORDER BY` clause only when `latest=True`. The general (`latest=False`) case has no `ORDER BY`, so SQLite returns rows in rowid order. That's chronological *by accident* — jobs are inserted in commit order — and the accident breaks the first time `rebuild-index` reinserts rows in a different order (e.g. filesystem directory order).

## Fix

One spot, `Index.find`:

| case | before | after |
| --- | --- | --- |
| general | *(no `ORDER BY`)* | `ORDER BY timestamp ASC, id ASC` |
| `latest` | `ORDER BY timestamp DESC LIMIT 1` | `ORDER BY timestamp DESC, id DESC LIMIT 1` |

- **Oldest-first** restores the historic (pre-SQLite) behavior, where `find` iterated an insertion-ordered dict.
- **`id` as a secondary key** gives a deterministic *total* order. `id` is stable and independent of insertion order, so ties survive `rebuild-index` — unlike rowid, which is exactly what a rebuild scrambles. Added to the `latest` branch too, so "which job is latest" is deterministic on a timestamp tie.

No API/CLI signature change — `Repository.find`, the `r3 find` CLI, and `FindAllDependency` resolution all inherit the ordering. Docstrings and the CLI help now state the contract.

### Rejected alternative

Leaving same-timestamp ordering unspecified: for the tie subset SQLite falls back to rowid order, which reintroduces the #60 class of bug (order flips on rebuild) for those rows. The `id` tie-break costs one indexed column in the sort and removes that entirely.

## Verification

- Three new tests in `test/test_index.py` (TDD): oldest-first ordering independent of insertion order; timestamp ties broken by id (non-`latest` and `latest`).
- The tie tests were confirmed to **fail** with the `id` tie-break removed and **pass** with it — they genuinely guard the behavior. They use 4 jobs so an accidental pass under arbitrary tie-ordering is negligible.
- Full suite: **184 passed** · `ruff`: clean · `mypy`: clean.