### PR TITLE
:memo: Drop stale run command from tutorial r3.yaml example

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -34,10 +34,6 @@ environment:
   container: *container
   gpus: none
 
-commands:
-  run: python run.py
-  done: ls output/test
-
 parameters:
   name: World
 ```


### PR DESCRIPTION
R3 makes no assumption about how a job is run — there is no run command. The
tutorial's `r3.yaml` example still carried a leftover `commands: run/done` block
implying otherwise; this removes it.

Note (not addressed here): the whole tutorial is already banner-flagged as
outdated and is stale throughout (`commit-data`, `item:` deps, `r3 dev checkout`,
`by_hash/…`). A broader tutorial refresh is left as separate work.
