### PR TITLE
:memo: Reconcile format & tutorial docs with current behavior

### DIFF
--- a/docs/repository_format.md
+++ b/docs/repository_format.md
@@ -12,7 +12,9 @@ for any interaction with repositories and stored jobs.
 - A repository is a folder with the following contents:
   - `r3.yaml`: Contains a single key `version` mapping to the version of this
     specification.
-  - `index.yaml` or `index.sqlite`: Optional cache of job metadata for fast retrieval.
+  - `index.sqlite`: Optional cache of job metadata for fast retrieval. (Older
+    repositories may still contain a legacy `index.yaml`; current R3 uses only
+    `index.sqlite`.)
   - `git/`: Cloned git repositories.
   - `jobs/`: Committed jobs.
 
@@ -24,7 +26,7 @@ for any interaction with repositories and stored jobs.
   `jobs/$uuid/`). Each job is assigned a uuid version 4 when committed to the
   repository.
 
-- Each job directory `job/$uuid/` is write protected and has the following contents:
+- Each job directory `jobs/$uuid/` is write protected and has the following contents:
   - `r3.yaml`: Job metadata used by R3 (write protected).
   - `metadata.yaml`: Custom job metadata that may be changed at any time.
   - `output/`: Directory for all job outputs. Contents may be changed.
@@ -53,14 +55,19 @@ for any interaction with repositories and stored jobs.
     - `commit` (git only): Full commit id.
     - `source`: Optional. A path relative to the item if only a specific subfolder
       or file is needed. For example: `output/checkpoints/best.pth`. Defaults to the
-      empty string.
+      empty string. Not applicable to `find_all` dependencies, which are always
+      checked out from the job root into per-job subdirectories of `destination`.
     - `destination`: A path relative to the job directory where the dependency will be
        checked out. For example: `pretrained_weights.pth`.
-    - `query` (job only): Optional. The original query that was resolved to this
-       dependency.
-  - `ignore`: A list of ignore patterns as used by git. The given patterns must not
-    match any file belonging to the job.
-  - `hashes`: A dictionary apping paths to hashes (as specified aboce). The key `.`
+    - `find_latest` / `find_all` (job only): Optional. The MongoDB-style query this
+       dependency was resolved from, recorded on the resolved dependency. (`query` /
+       `query_all` are the deprecated equivalents.)
+  - `ignore`: A list of ignore patterns. Currently only absolute patterns naming a
+    top-level file or directory are supported (e.g. `/output`, `/__pycache__`);
+    patterns not starting with `/` raise an error, and glob / `.gitignore`-style
+    matching is not supported. The given patterns must not match any file belonging to
+    the job.
+  - `hashes`: A dictionary mapping paths to hashes (as specified above). The key `.`
     maps to the overall job hash.
   - `timestamp`: The timestamp when the job was created as an ISO 8601 string.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -11,7 +11,7 @@ r3 init path/to/repository
 
 Data files or directories can be added to the repository using the `commit-data`
 command. The command returns the path to the job within the repository, that can be
-used to specifiy dependencies later.
+used to specify dependencies later.
 
 ```bash
 $ r3 commit-data container-v1.sif --tag container
@@ -50,9 +50,6 @@ name = parameters.get("name", "World")
 with open("output/test", "w") as output_file:
     output_file.write(f"Hello {name}!")
 ```
-
-To facilitate developing jobs, dependencies for uncomitted jobs can be checked out
-using `r3 dev checkout`.
 
 Now commit your job to the repository:
 ```


### PR DESCRIPTION
## What

Fixes several places where `docs/repository_format.md` and `docs/tutorial.md`
describe behavior R3 no longer has. Both files are acknowledged as partly outdated,
but these particular statements repeatedly sent readers — and coding agents — down
wrong paths, so this removes/corrects the obviously-wrong parts. This is a targeted
accuracy pass, not a rewrite; the tutorial keeps its "outdated" banner.

## Changes

**`docs/tutorial.md`**
- Drop the reference to `r3 dev checkout` — that CLI command was removed
  (`4da2253 refactor: remove dev checkout from cli`); only the `Repository.checkout`
  Python primitive remains, with no CLI equivalent.
- Typo: `specifiy` → `specify`.

**`docs/repository_format.md`**
- **`ignore`** was described as "patterns as used by git". In fact `utils.find_files`
  supports only absolute patterns naming a top-level file/directory (e.g. `/output`);
  a pattern not starting with `/` raises `NotImplementedError`, and there is no glob
  or `.gitignore` matching. Documented the actual (narrow) behavior.
- **Dependency query key**: the generic `query` key is replaced by the keys the code
  actually emits — `find_latest` / `find_all` — with `query` / `query_all` noted as
  the deprecated equivalents.
- **`source`**: noted that it does not apply to `find_all` dependencies, which are
  source-less by design — each match is checked out from the job root into a per-job
  subdirectory of `destination` (named by job id).
- **`index`**: only `index.sqlite` is used by current R3; `index.yaml` is a legacy
  leftover, now noted as such.
- Typos: `job/$uuid/` → `jobs/$uuid/` (wrong path), `apping` → `mapping`,
  `aboce` → `above`.

## Not changed
- The repository-format spec version (`1.0.0-beta.7`) is left untouched — these are
  description-accuracy fixes, not on-disk format changes.
- The previously-stale `commands: run: python run.py` block in the tutorial was
  already removed in #75, so it is not part of this PR.

## Verification
- `ignore` behavior — `r3/utils.py` (`_find_files` / `_is_ignored`).
- dependency keys — `r3/job.py` (`JobDependency` / `FindLatestDependency` /
  `FindAllDependency` `to_config`) and `r3/repository.py`
  (`_resolve_find_latest_dependency` / `_resolve_find_all_dependency`).
- index format — `r3/index.py` (uses only `index.sqlite`).
- removed CLI command — no `dev` group in `r3/cli.py`.
