### PR TITLE
:memo: Correct ignore-pattern description in repository_format

### DIFF
--- a/docs/repository_format.md
+++ b/docs/repository_format.md
@@ -62,11 +62,10 @@ for any interaction with repositories and stored jobs.
     - `find_latest` / `find_all` (job only): Optional. The MongoDB-style query this
        dependency was resolved from, recorded on the resolved dependency. (`query` /
        `query_all` are the deprecated equivalents.)
-  - `ignore`: A list of ignore patterns. Currently only absolute patterns naming a
-    top-level file or directory are supported (e.g. `/output`, `/__pycache__`);
-    patterns not starting with `/` raise an error, and glob / `.gitignore`-style
-    matching is not supported. The given patterns must not match any file belonging to
-    the job.
+  - `ignore`: A list of ignore patterns. Each pattern is an absolute path from the job
+    root (e.g. `/output`, `/__pycache__`, `/output/cache`) and is matched exactly, with
+    no glob or `.gitignore`-style matching; patterns not starting with `/` raise an
+    error. The given patterns must not match any file belonging to the job.
   - `hashes`: A dictionary mapping paths to hashes (as specified above). The key `.`
     maps to the overall job hash.
   - `timestamp`: The timestamp when the job was created as an ISO 8601 string.


### PR DESCRIPTION
## What

Follow-up to #76. That PR rewrote the `ignore` description but under-stated what's
supported: it said only **top-level** absolute patterns work.

In fact `_find_files` recurses into each non-ignored subdirectory with the matched
prefix stripped from the patterns (`r3/utils.py`), so **nested** absolute paths such as
`/output/cache` are matched too — not just top-level names.

This restates the rule accurately and more simply: an ignore pattern is an absolute path
from the job root, matched exactly (no glob / `.gitignore` semantics), and a pattern not
starting with `/` raises an error.

## Verification
- `r3/utils.py` `_find_files` / `_is_ignored` — recursion strips `/{child}` from patterns
  before descending, so `/output/cache` ignores that subtree.
- Regression test for the recursion:
  `test/test_utils.py::test_find_files_ignores_sibling_dirs_after_recursing_into_earlier_sibling`.
