### PR TITLE
:sparkles: r3 find: path column, --path filter, --tags/--no-tags

### DIFF
--- a/r3/cli.py
+++ b/r3/cli.py
@@ -3,7 +3,7 @@
 
 import sys
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import click
 
@@ -154,6 +154,15 @@ def remove(job_id: str, repository_path: Optional[Path]) -> None:
     )
 )
 @click.option(
+    "--path", "-p", "path_glob", type=str, default=None,
+    help=(
+        "Only list jobs whose `path` matches this glob pattern. The pattern is a "
+        "literal SQLite GLOB (`*`, `?`, `[...]` are wildcards) and you add the "
+        "wildcards yourself, e.g. -p '*mnist*' or -p 'proj/experiments/*'. "
+        "Combined with --tag via AND."
+    )
+)
+@click.option(
     "--latest/--all", default=False,
     help="Whether to list all job matching the given conditions or only the latest job."
 )
@@ -164,6 +173,13 @@ def remove(job_id: str, repository_path: Optional[Path]) -> None:
     )
 )
 @click.option(
+    "--tags/--no-tags", "show_tags", default=True,
+    help=(
+        "Include the tags column in --long output (default: --tags). Use "
+        "--no-tags to drop it; the path column already shows where a job lives."
+    )
+)
+@click.option(
     "--repository",
     "repository_path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
@@ -171,22 +187,43 @@ def remove(job_id: str, repository_path: Optional[Path]) -> None:
     show_envvar=True,
 )
 def find(
-    tags: Iterable[str], latest: bool, long: bool, repository_path: Optional[Path]
+    tags: Iterable[str],
+    path_glob: Optional[str],
+    latest: bool,
+    long: bool,
+    show_tags: bool,
+    repository_path: Optional[Path],
 ) -> None:
     """Searches the R3 repository for jobs matching the given conditions.
 
     Results are listed oldest-first by timestamp.
     """
     repository = _get_repository(repository_path)
-    query = {"tags": {"$all": tags}}
+    query = _build_find_query(tags, path_glob)
     for job in repository.find(query, latest):
         if long:
             assert job.timestamp is not None
-            datetime = job.timestamp.strftime(r"%Y-%m-%d %H:%M:%S")
-            tags = " ".join(f"#{tag}" for tag in job.metadata.get("tags", []))
-            print(f"{job.id} | {datetime} | {tags}")
+            datetime_str = job.timestamp.strftime(r"%Y-%m-%d %H:%M:%S")
+            path = job.metadata.get("path", "")
+            line = f"{job.id} | {datetime_str} | {path}"
+            if show_tags:
+                tags_str = " ".join(
+                    f"#{tag}" for tag in job.metadata.get("tags", [])
+                )
+                line += f" | {tags_str}"
+            print(line)
         else:
             print(job.id)
+
+
+def _build_find_query(
+    tags: Iterable[str], path_glob: Optional[str]
+) -> Dict[str, Any]:
+    """Builds the Mongo-style query for `find` from the tag/path options."""
+    query: Dict[str, Any] = {"tags": {"$all": list(tags)}}
+    if path_glob is not None:
+        query["path"] = {"$glob": path_glob}
+    return query
 
 
 @cli.command()

--- a/r3/cli.py
+++ b/r3/cli.py
@@ -175,8 +175,7 @@ def remove(job_id: str, repository_path: Optional[Path]) -> None:
 @click.option(
     "--tags/--no-tags", "show_tags", default=True,
     help=(
-        "Include the tags column in --long output (default: --tags). Use "
-        "--no-tags to drop it; the path column already shows where a job lives."
+        "Include the tags column in --long output (default: --tags)."
     )
 )
 @click.option(

--- a/r3/query.py
+++ b/r3/query.py
@@ -10,8 +10,8 @@ def _sql_str(value: str) -> str:
 
     Values are interpolated into SQL directly (not bound), so any `'` in a
     user-supplied string — e.g. an `r3 find --path` pattern — must be escaped or
-    it breaks/injects the query. This is the minimal fix; parameter binding is a
-    tracked follow-up.
+    it breaks/injects the query. Might be replaced by proper parameter binding in
+    the future.
     """
     return "'" + value.replace("'", "''") + "'"
 

--- a/r3/query.py
+++ b/r3/query.py
@@ -5,6 +5,17 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 
+def _sql_str(value: str) -> str:
+    """Return a SQL string literal for `value`, with embedded single quotes doubled.
+
+    Values are interpolated into SQL directly (not bound), so any `'` in a
+    user-supplied string — e.g. an `r3 find --path` pattern — must be escaped or
+    it breaks/injects the query. This is the minimal fix; parameter binding is a
+    tracked follow-up.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
 def mongo_to_sql(query: Dict[str, Any]) -> str:
     """Converts a MongoDB query document to a SQL query."""
     return Query.from_mongo(query).to_sql()
@@ -175,7 +186,7 @@ class Eq(Condition):
 
     def to_sql(self, field: str) -> str:
         if isinstance(self.value, str):
-            return f"{field} = '{self.value}'"
+            return f"{field} = {_sql_str(self.value)}"
         else:
             return f"{field} = {self.value}"
 
@@ -191,7 +202,7 @@ class Ne(Condition):
 
     def to_sql(self, field: str) -> str:
         if isinstance(self.value, str):
-            return f"{field} != '{self.value}'"
+            return f"{field} != {_sql_str(self.value)}"
         else:
             return f"{field} != {self.value}"
 
@@ -207,7 +218,7 @@ class In(Condition):
 
     def to_sql(self, field: str) -> str:
         values = [
-            f"'{value}'" if isinstance(value, str) else str(value)
+            _sql_str(value) if isinstance(value, str) else str(value)
             for value in self.values
         ]
         return f"{field} IN ({', '.join(values)})"
@@ -224,7 +235,7 @@ class Nin(Condition):
 
     def to_sql(self, field: str) -> str:
         values = [
-            f"'{value}'" if isinstance(value, str) else str(value)
+            _sql_str(value) if isinstance(value, str) else str(value)
             for value in self.values
         ]
         return f"{field} NOT IN ({', '.join(values)})"
@@ -292,7 +303,7 @@ class Glob(Condition):
         return True
 
     def to_sql(self, field: str) -> str:
-        return f"{field} GLOB '{self.pattern}'"
+        return f"{field} GLOB {_sql_str(self.pattern)}"
 
 
 @dataclass
@@ -309,7 +320,7 @@ class All(Condition):
             return "TRUE"
 
         subqueries = [
-            f"EXISTS (SELECT 1 FROM json_each({field}) WHERE value = '{value}')"
+            f"EXISTS (SELECT 1 FROM json_each({field}) WHERE value = {_sql_str(value)})"
             if isinstance(value, str)
             else f"EXISTS (SELECT 1 FROM json_each({field}) WHERE value = {value})"
             for value in self.values

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -37,6 +37,18 @@ def commit_dependent_job(repository: Repository, job: Job, destination: str) -> 
     return repository.commit(dependent_job)
 
 
+def _commit_with(repository: Repository, name: str, path: str, tags):
+    """Commits `test/data/jobs/<name>` with the given path/tags metadata.
+
+    NB: `storage.add` sets timestamp = now(), so rely on commit *order* for time
+    and read timestamps back from the returned committed job.
+    """
+    job = get_dummy_job(name)
+    job.metadata["path"] = path
+    job.metadata["tags"] = list(tags)
+    return repository.commit(job)
+
+
 def test_remove_removes_job(repository: Repository) -> None:
     job = repository.commit(get_dummy_job("base"))
     assert job.id is not None
@@ -227,3 +239,80 @@ def test_help_mentions_the_repository_env_var() -> None:
 
     assert result.exit_code == 0
     assert "R3_REPOSITORY" in result.output
+
+
+def test_find_long_shows_path_before_tags(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/pilot", ["a", "b"])
+    result = CliRunner().invoke(
+        cli, ["find", "-l", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    line = result.output.strip().splitlines()[0]
+    # Columns: id | datetime | path | tags
+    assert " | proj/exp/pilot | " in line
+    assert line.index("proj/exp/pilot") < line.index("#a")
+
+
+def test_find_long_blank_path_column_when_absent(repository: Repository) -> None:
+    job = get_dummy_job("base")
+    job.metadata["tags"] = ["only-tag"]
+    repository.commit(job)
+    result = CliRunner().invoke(
+        cli, ["find", "-l", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    # path column present but empty, still before tags
+    assert " |  | #only-tag" in result.output
+
+
+def test_find_path_filter_is_literal_glob(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/pilot", [])
+    _commit_with(repository, "base", "proj/other/run", [])
+    result = CliRunner().invoke(
+        cli, ["find", "-p", "proj/exp/*", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    ids = set(result.output.split())
+    pilot = repository.find({"path": "proj/exp/pilot"})[0]
+    other = repository.find({"path": "proj/other/run"})[0]
+    assert pilot.id in ids
+    assert other.id not in ids
+
+
+def test_find_path_filter_no_automatic_wildcard(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp", [])
+    _commit_with(repository, "base", "proj/experiment", [])
+    result = CliRunner().invoke(
+        cli, ["find", "-p", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    exp = repository.find({"path": "proj/exp"})[0]
+    experiment = repository.find({"path": "proj/experiment"})[0]
+    ids = set(result.output.split())
+    assert exp.id in ids
+    assert experiment.id not in ids
+
+
+def test_find_path_and_tag_are_anded(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/a", ["keep"])
+    _commit_with(repository, "base", "proj/exp/b", ["drop"])
+    result = CliRunner().invoke(
+        cli,
+        ["find", "-p", "proj/exp/*", "-t", "keep",
+         "--repository", str(repository.path)],
+    )
+    assert result.exit_code == 0
+    keep = repository.find({"path": "proj/exp/a"})[0]
+    drop = repository.find({"path": "proj/exp/b"})[0]
+    ids = set(result.output.split())
+    assert keep.id in ids and drop.id not in ids
+
+
+def test_find_no_tags_drops_tags_column(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/pilot", ["a"])
+    result = CliRunner().invoke(
+        cli, ["find", "-l", "--no-tags", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    assert "#a" not in result.output
+    assert "proj/exp/pilot" in result.output

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -257,8 +257,37 @@ CONDITION_TEST_CASES = [
         {"$elemMatch": {"$gt": 28, "$lt": 32}},
         "EXISTS (SELECT 1 FROM json_each(field) WHERE value > 28 AND value < 32)",
     ),
+    # single quotes in string values must be doubled, not left to break the SQL
+    ({"$eq": "a'b"},                 "field = 'a''b'"),
+    ({"$ne": "a'b"},                 "field != 'a''b'"),
+    ({"$glob": "a'b*"},              "field GLOB 'a''b*'"),
+    ({"$in": ["a'b"]},               "field IN ('a''b')"),
 ]
 @pytest.mark.parametrize("mongo,sql", CONDITION_TEST_CASES)
 def test_condition_to_sql(mongo, sql):
     condition = Condition.from_mongo(mongo)
     assert condition.to_sql("field") == sql
+
+
+def test_string_values_with_single_quotes_are_escaped(tmp_path):
+    path = tmp_path / "db.sqlite"
+    connection = sqlite3.connect(path)
+    cursor = connection.cursor()
+    cursor.execute("CREATE TABLE jobs (id TEXT PRIMARY KEY, metadata JSON NOT NULL)")
+    cursor.execute(
+        "INSERT INTO jobs (id, metadata) VALUES (?, ?)",
+        ("j1", json.dumps({"path": "a'b/c"})),
+    )
+    connection.commit()
+
+    # Must not raise (no broken/injected SQL) and must match literally.
+    # (Build the WHERE clause first — an f-string can't contain the backslashes/
+    # nested quotes this would otherwise need on Python < 3.12.)
+    glob_where = mongo_to_sql({"path": {"$glob": "a'b/*"}})
+    cursor.execute("SELECT id FROM jobs WHERE " + glob_where)
+    assert {row[0] for row in cursor.fetchall()} == {"j1"}
+
+    eq_where = mongo_to_sql({"path": "a'b/c"})
+    cursor.execute("SELECT id FROM jobs WHERE " + eq_where)
+    assert {row[0] for row in cursor.fetchall()} == {"j1"}
+    connection.close()


### PR DESCRIPTION
The first half of **path promotion**: first-class `metadata.path` support in
`r3 find`, plus a safety fix in the query layer. The `r3 ls` browser follows in
a separate PR.

## Summary

- **`r3 find -l`** now shows `metadata.path` as a column, before the tags column
  (blank when a job has no path): `id | datetime | path | tags`.
- **`r3 find --path/-p GLOB`** filters on `metadata.path` via a literal SQLite
  GLOB (you add the wildcards, e.g. `-p '*mnist*'` or `-p 'proj/exp/*'`), AND-ed
  with `--tag`.
- **`r3 find --tags/--no-tags`** toggles the tags column in `--long` output.
- **`query.py`**: string values are interpolated into SQL directly, so a value
  containing `'` (now reachable via `--path`) could break or inject the query.
  All string literals (`Eq`/`Ne`/`In`/`Nin`/`Glob`/`All`) now go through a
  `_sql_str` helper that doubles quotes. Proper parameter binding is left as a
  follow-up.

This upstreams behavior that has been in daily use in the `xr3` house wrapper.

## Test plan

- [x] `test/test_query.py` — quote-escaping unit cases + a SQLite integration
  test that a value containing `'` matches literally and does not error.
- [x] `test/test_cli.py` — `-l` path column placement (and blank when absent),
  `-p` literal-GLOB semantics (no implicit `*`), `-p` AND `--tag`, `--no-tags`.
- [x] Full suite green (`pytest`), `ruff` and `mypy` clean.
