### PR TITLE
:sparkles: r3 ls: browse jobs by their metadata.path

### DIFF
--- a/r3/cli.py
+++ b/r3/cli.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, Optional
 import click
 
 import r3
+import r3.ls
 
 
 @click.group(
@@ -223,6 +224,44 @@ def _build_find_query(
     if path_glob is not None:
         query["path"] = {"$glob": path_glob}
     return query
+
+
+@cli.command()
+@click.argument("prefix", type=str, default="")
+@click.option("--long/--short", "-l", default=False,
+    help="Show the job id and tags for each job entry, not just its timestamp.")
+@click.option(
+    "--tags/--no-tags", "show_tags", default=True,
+    help="Include tags in --long output (default: --tags).")
+@click.option("--time/--name", "-t", "by_time", default=False,
+    help="Sort by timestamp (newest first) instead of alphabetically.")
+@click.option(
+    "--repository",
+    "repository_path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    envvar="R3_REPOSITORY",
+    show_envvar=True,
+)
+def ls(
+    prefix: str,
+    long: bool,
+    show_tags: bool,
+    by_time: bool,
+    repository_path: Optional[Path],
+) -> None:
+    """Lists one level of the job virtual filesystem under PREFIX.
+
+    Jobs are organized by their `metadata.path`. This shows the job(s) sitting
+    exactly at PREFIX (as `.`), jobs one level below it, and sub-directories
+    (names with `/`). Jobs without a `path` are not shown. With no PREFIX, lists
+    the top level.
+    """
+    repository = _get_repository(repository_path)
+    query = r3.ls.query_for_prefix(prefix)
+    jobs = repository.find(query)
+    entries = r3.ls.build_listing(jobs, prefix, by_time=by_time)
+    if entries:
+        print(r3.ls.format_listing(entries, long=long, show_tags=show_tags))
 
 
 @cli.command()

--- a/r3/ls.py
+++ b/r3/ls.py
@@ -71,7 +71,7 @@ def build_listing(
         elif path.startswith(prefix + "/"):
             remainder = path[len(prefix) + 1:]
         else:
-            continue  # outside the prefix (defensive; query shouldn't return these)
+            continue  # path is not under prefix: skip
 
         if "/" in remainder:
             dirs.setdefault(remainder.split("/", 1)[0], []).append(job)

--- a/r3/ls.py
+++ b/r3/ls.py
@@ -1,0 +1,149 @@
+"""Virtual-filesystem listing over the `metadata.path` convention (r3 ls)."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class Entry:
+    """One row of an `r3 ls` listing."""
+
+    kind: str  # "self" | "leaf" | "dir"
+    name: str  # "." for self; the leaf/dir segment otherwise (no trailing slash)
+    timestamp: Optional[datetime] = None
+    revisions: int = 0
+    job_id: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    sort_time: Optional[datetime] = None
+
+
+def normalize_prefix(prefix: str) -> str:
+    """Strips trailing slashes; a bare '/' or '' both mean the root."""
+    return prefix.rstrip("/")
+
+
+def escape_glob_literal(literal: str) -> str:
+    """Escapes SQLite GLOB metacharacters (* ? [) so a literal path is matched
+    literally (SQLite GLOB has no backslash escape; wrap each in a class)."""
+    return "".join(f"[{ch}]" if ch in "*?[" else ch for ch in literal)
+
+
+def query_for_prefix(prefix: str) -> Dict[str, Any]:
+    """Query matching the job(s) at exactly `prefix` plus everything one or more
+    levels below it. At the root, matches every job that has a path."""
+    prefix = normalize_prefix(prefix)
+    if prefix == "":
+        return {"path": {"$glob": "*"}}
+    return {
+        "$or": [
+            {"path": prefix},
+            {"path": {"$glob": escape_glob_literal(prefix) + "/*"}},
+        ]
+    }
+
+
+def build_listing(
+    jobs: Iterable[Any], prefix: str, by_time: bool = False
+) -> List[Entry]:
+    """Partitions matched jobs into a one-level listing under `prefix`.
+
+    `jobs` are the results of `query_for_prefix(prefix)`; each is read only for
+    `.metadata` (`path`, `tags`), `.timestamp`, and `.id`. Jobs without a `path`
+    are ignored. Revisions (jobs sharing an exact path) collapse to one entry.
+    """
+    prefix = normalize_prefix(prefix)
+
+    self_jobs: List[Any] = []
+    leaves: Dict[str, List[Any]] = {}
+    dirs: Dict[str, List[Any]] = {}
+
+    for job in jobs:
+        path = job.metadata.get("path")
+        if path is None:
+            continue
+
+        if prefix == "":
+            remainder = path
+        elif path == prefix:
+            self_jobs.append(job)
+            continue
+        elif path.startswith(prefix + "/"):
+            remainder = path[len(prefix) + 1:]
+        else:
+            continue  # outside the prefix (defensive; query shouldn't return these)
+
+        if "/" in remainder:
+            dirs.setdefault(remainder.split("/", 1)[0], []).append(job)
+        else:
+            leaves.setdefault(remainder, []).append(job)
+
+    entries: List[Entry] = []
+
+    def _job_entry(kind: str, name: str, group: List[Any]) -> Entry:
+        latest = max(group, key=lambda j: j.timestamp)
+        return Entry(
+            kind=kind,
+            name=name,
+            timestamp=latest.timestamp,
+            revisions=len(group),
+            job_id=latest.id,
+            tags=list(latest.metadata.get("tags", [])),
+            sort_time=latest.timestamp,
+        )
+
+    if self_jobs:
+        entries.append(_job_entry("self", ".", self_jobs))
+    for name, group in leaves.items():
+        entries.append(_job_entry("leaf", name, group))
+    for name, group in dirs.items():
+        entries.append(
+            Entry(kind="dir", name=name, sort_time=max(j.timestamp for j in group))
+        )
+
+    def sort_key(entry: Entry):
+        self_first = entry.kind != "self"
+        if by_time:
+            # newest first among non-self; sort_time is always set here
+            assert entry.sort_time is not None
+            return (self_first, -entry.sort_time.timestamp())
+        # alphabetical; on a leaf/dir name tie, the leaf precedes its dir
+        return (self_first, entry.name, 0 if entry.kind == "leaf" else 1)
+
+    entries.sort(key=sort_key)
+    return entries
+
+
+def format_listing(
+    entries: Iterable[Entry], long: bool = False, show_tags: bool = True
+) -> str:
+    """Renders entries as aligned text (job rows carry a timestamp; dir rows are
+    just `name/`)."""
+    entries = list(entries)
+
+    def display_name(entry: Entry) -> str:
+        return entry.name + "/" if entry.kind == "dir" else entry.name
+
+    width = max((len(display_name(e)) for e in entries), default=0)
+
+    lines: List[str] = []
+    for entry in entries:
+        name = display_name(entry)
+        if entry.kind == "dir":
+            lines.append(name)
+            continue
+
+        assert entry.timestamp is not None
+        timestamp = entry.timestamp.strftime(r"%Y-%m-%d %H:%M:%S")
+        revisions = f" ({entry.revisions} revisions)" if entry.revisions > 1 else ""
+        if long:
+            tags = ""
+            if show_tags:
+                tags = " | " + " ".join(f"#{tag}" for tag in entry.tags)
+            lines.append(
+                f"{name:<{width}}  {entry.job_id} | {timestamp}{tags}{revisions}"
+            )
+        else:
+            lines.append(f"{name:<{width}}  {timestamp}{revisions}")
+
+    return "\n".join(lines)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -327,6 +327,7 @@ def test_ls_lists_one_level(repository: Repository) -> None:
     )
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()
+    assert len(lines) == 2  # grid/run1 + grid/run2 collapse into a single grid/ entry
     # alphabetical, interleaved: "grid" (dir) before "pilot" (leaf)
     assert lines[0].strip() == "grid/"
     assert lines[1].startswith("pilot")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -316,3 +316,116 @@ def test_find_no_tags_drops_tags_column(repository: Repository) -> None:
     assert result.exit_code == 0
     assert "#a" not in result.output
     assert "proj/exp/pilot" in result.output
+
+
+def test_ls_lists_one_level(repository: Repository) -> None:
+    pilot = _commit_with(repository, "base", "proj/exp/pilot", [])
+    _commit_with(repository, "base", "proj/exp/grid/run1", [])
+    _commit_with(repository, "base", "proj/exp/grid/run2", [])
+    result = CliRunner().invoke(
+        cli, ["ls", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    # alphabetical, interleaved: "grid" (dir) before "pilot" (leaf)
+    assert lines[0].strip() == "grid/"
+    assert lines[1].startswith("pilot")
+    assert pilot.timestamp.strftime(r"%Y-%m-%d %H:%M:%S") in lines[1]
+
+
+def test_ls_self_entry_for_job_at_prefix(repository: Repository) -> None:
+    self_job = _commit_with(repository, "base", "proj/exp", [])
+    _commit_with(repository, "base", "proj/exp/pilot", [])
+    result = CliRunner().invoke(
+        cli, ["ls", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert lines[0].startswith(".")
+    assert self_job.timestamp.strftime(r"%Y-%m-%d %H:%M:%S") in lines[0]
+
+
+def test_ls_collision_shows_job_and_dir(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/analysis", [])
+    _commit_with(repository, "base", "proj/exp/analysis/report", [])
+    result = CliRunner().invoke(
+        cli, ["ls", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    # analysis is both a job leaf and a directory: both lines, leaf then dir
+    assert lines[0].startswith("analysis") and not lines[0].strip().endswith("/")
+    assert lines[1].strip() == "analysis/"
+
+
+def test_ls_revision_count_and_latest(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/pilot", ["v1"])
+    newer = _commit_with(repository, "base", "proj/exp/pilot", ["v2"])
+    result = CliRunner().invoke(
+        cli, ["ls", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    assert "(2 revisions)" in result.output
+    # latest revision (committed last -> later now()) supplies the timestamp
+    assert newer.timestamp.strftime(r"%Y-%m-%d %H:%M:%S") in result.output
+
+
+def test_ls_root_lists_top_level(repository: Repository) -> None:
+    _commit_with(repository, "base", "projA/exp/pilot", [])
+    _commit_with(repository, "base", "single", [])
+    result = CliRunner().invoke(
+        cli, ["ls", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    out = result.output
+    assert "projA/" in out
+    assert "single" in out
+
+
+def test_ls_trailing_slash_is_insignificant(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/pilot", [])
+    with_slash = CliRunner().invoke(
+        cli, ["ls", "proj/exp/", "--repository", str(repository.path)]
+    )
+    without_slash = CliRunner().invoke(
+        cli, ["ls", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert with_slash.output == without_slash.output
+
+
+def test_ls_empty_when_no_match(repository: Repository) -> None:
+    _commit_with(repository, "base", "proj/exp/pilot", [])
+    result = CliRunner().invoke(
+        cli, ["ls", "nope/here", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_ls_long_shows_id_and_tags(repository: Repository) -> None:
+    job = _commit_with(repository, "base", "proj/exp/pilot", ["t1"])
+    result = CliRunner().invoke(
+        cli, ["ls", "-l", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert result.exit_code == 0
+    assert job.id in result.output
+    assert "#t1" in result.output
+    no_tags = CliRunner().invoke(
+        cli, ["ls", "-l", "--no-tags", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert "#t1" not in no_tags.output
+
+
+def test_ls_time_sort_differs_from_alphabetical(repository: Repository) -> None:
+    # Commit "aaa" first (older), "zzz" second (newer):
+    # alphabetical -> aaa, zzz ; time (newest first) -> zzz, aaa.
+    _commit_with(repository, "base", "proj/exp/aaa", [])
+    _commit_with(repository, "base", "proj/exp/zzz", [])
+    alpha = CliRunner().invoke(
+        cli, ["ls", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert [ln.split()[0] for ln in alpha.output.strip().splitlines()] == ["aaa", "zzz"]
+    timed = CliRunner().invoke(
+        cli, ["ls", "-t", "proj/exp", "--repository", str(repository.path)]
+    )
+    assert [ln.split()[0] for ln in timed.output.strip().splitlines()] == ["zzz", "aaa"]

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -125,10 +125,12 @@ def test_build_listing_by_time_orders_newest_first_self_still_first():
 
 
 def test_format_listing_default_and_long():
+    ts1 = datetime.datetime(2026, 6, 1, 9, 0, 0)
+    ts2 = datetime.datetime(2026, 6, 2, 10, 0, 0)
     entries = [
-        Entry(kind="self", name=".", timestamp=datetime.datetime(2026, 6, 1, 9, 0, 0),
+        Entry(kind="self", name=".", timestamp=ts1,
               revisions=2, job_id="jid", tags=["main"]),
-        Entry(kind="leaf", name="eval", timestamp=datetime.datetime(2026, 6, 2, 10, 0, 0),
+        Entry(kind="leaf", name="eval", timestamp=ts2,
               revisions=1, job_id="jid2", tags=["eval"]),
         Entry(kind="dir", name="tasks"),
     ]

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -1,0 +1,146 @@
+import datetime
+from types import SimpleNamespace
+
+from r3.ls import (
+    Entry,
+    build_listing,
+    escape_glob_literal,
+    format_listing,
+    normalize_prefix,
+    query_for_prefix,
+)
+
+
+def _job(path, ts, id="id", tags=None):
+    return SimpleNamespace(
+        metadata={"path": path, "tags": tags or []},
+        timestamp=datetime.datetime(2026, 1, 1) + datetime.timedelta(days=ts),
+        id=id,
+    )
+
+
+def test_normalize_prefix_strips_trailing_slashes():
+    assert normalize_prefix("a/b/") == "a/b"
+    assert normalize_prefix("a/b//") == "a/b"
+    assert normalize_prefix("a/b") == "a/b"
+    assert normalize_prefix("") == ""
+    assert normalize_prefix("/") == ""
+
+
+def test_escape_glob_literal_wraps_metacharacters():
+    assert escape_glob_literal("a*b?c[d") == "a[*]b[?]c[[]d"
+    assert escape_glob_literal("proj/exp") == "proj/exp"
+
+
+def test_query_for_prefix_root_matches_any_path():
+    assert query_for_prefix("") == {"path": {"$glob": "*"}}
+
+
+def test_query_for_prefix_non_root_is_self_or_children():
+    assert query_for_prefix("proj/exp/") == {
+        "$or": [
+            {"path": "proj/exp"},
+            {"path": {"$glob": "proj/exp/*"}},
+        ]
+    }
+
+
+def test_query_for_prefix_escapes_children_glob():
+    assert query_for_prefix("a*b") == {
+        "$or": [
+            {"path": "a*b"},
+            {"path": {"$glob": "a[*]b/*"}},
+        ]
+    }
+
+
+def test_build_listing_partitions_self_leaf_dir():
+    jobs = [
+        _job("proj/exp", 5, id="self"),
+        _job("proj/exp/pilot", 1, id="pilot"),
+        _job("proj/exp/grid/run1", 2, id="g1"),
+        _job("proj/exp/grid/run2", 3, id="g2"),
+    ]
+    entries = build_listing(jobs, "proj/exp")
+    kinds = [(e.kind, e.name) for e in entries]
+    # self first, then alphabetical interleave: "grid" (dir) sorts before "pilot"
+    assert kinds == [("self", "."), ("dir", "grid"), ("leaf", "pilot")]
+
+
+def test_build_listing_collision_shows_both_lines():
+    jobs = [
+        _job("proj/exp/analysis", 5, id="a"),
+        _job("proj/exp/analysis/report", 6, id="r"),
+        _job("proj/exp/pilot", 1, id="p"),
+    ]
+    entries = build_listing(jobs, "proj/exp")
+    kinds = [(e.kind, e.name) for e in entries]
+    # analysis is both a leaf and a dir; leaf comes just before its dir
+    assert kinds == [
+        ("leaf", "analysis"),
+        ("dir", "analysis"),
+        ("leaf", "pilot"),
+    ]
+
+
+def test_build_listing_groups_revisions_latest_wins():
+    jobs = [
+        _job("proj/exp/pilot", 1, id="old", tags=["v1"]),
+        _job("proj/exp/pilot", 3, id="new", tags=["v2"]),
+        _job("proj/exp/pilot", 2, id="mid", tags=["v1b"]),
+    ]
+    entries = build_listing(jobs, "proj/exp")
+    (leaf,) = [e for e in entries if e.kind == "leaf"]
+    assert leaf.revisions == 3
+    assert leaf.job_id == "new"          # latest by timestamp
+    assert leaf.tags == ["v2"]
+    assert leaf.timestamp == datetime.datetime(2026, 1, 4)  # day 3
+
+
+def test_build_listing_root_uses_full_path_segments():
+    jobs = [_job("proj/exp/pilot", 1), _job("single", 2)]
+    entries = build_listing(jobs, "")
+    kinds = [(e.kind, e.name) for e in entries]
+    assert ("dir", "proj") in kinds
+    assert ("leaf", "single") in kinds
+
+
+def test_build_listing_ignores_jobs_without_path():
+    jobs = [
+        _job("proj/exp/pilot", 1),
+        SimpleNamespace(metadata={}, timestamp=None, id="x"),
+    ]
+    entries = build_listing(jobs, "proj/exp")
+    assert [e.name for e in entries] == ["pilot"]
+
+
+def test_build_listing_by_time_orders_newest_first_self_still_first():
+    jobs = [
+        _job("proj/exp", 9, id="self"),
+        _job("proj/exp/old", 1),
+        _job("proj/exp/new", 8),
+    ]
+    entries = build_listing(jobs, "proj/exp", by_time=True)
+    assert [e.name for e in entries] == [".", "new", "old"]
+
+
+def test_format_listing_default_and_long():
+    entries = [
+        Entry(kind="self", name=".", timestamp=datetime.datetime(2026, 6, 1, 9, 0, 0),
+              revisions=2, job_id="jid", tags=["main"]),
+        Entry(kind="leaf", name="eval", timestamp=datetime.datetime(2026, 6, 2, 10, 0, 0),
+              revisions=1, job_id="jid2", tags=["eval"]),
+        Entry(kind="dir", name="tasks"),
+    ]
+    short = format_listing(entries, long=False)
+    assert "." in short and "(2 revisions)" in short
+    assert "2026-06-01 09:00:00" in short
+    assert "tasks/" in short
+    assert "(1 revisions)" not in short          # singular not annotated
+
+    long = format_listing(entries, long=True, show_tags=True)
+    assert "jid | 2026-06-01 09:00:00 | #main (2 revisions)" in long
+    assert "#eval" in long
+
+    no_tags = format_listing(entries, long=True, show_tags=False)
+    assert "#main" not in no_tags


### PR DESCRIPTION
Adds `r3 ls`, a virtual-filesystem browser over the `metadata.path` convention —
the second half of path promotion. The `find`
half (path column, `-p`, `--tags/--no-tags`) landed in #78.

## What it does

`r3 ls <prefix>` lists one level of the path tree under `<prefix>`:

- **`.`** — the job(s) sitting *exactly* at `<prefix>` (with `(N revisions)` and
  the latest timestamp)
- **`<name>`** — a job one level below
- **`<name>/`** — a sub-directory (jobs live deeper under it)
- a name that is **both** a job and a directory shows **both** lines — nothing is
  ever hidden
- jobs without a `path` are not part of the virtual filesystem

Alphabetical and interleaved (leaves and dirs together, `.` first). Flags: `-l`
(job id + tags), `--tags/--no-tags`, `-t` (sort by timestamp, newest first), and
a root listing with no argument. A trailing slash on the prefix is insignificant,
and the literal prefix's GLOB metacharacters are escaped.

Implemented as a pure, repo-independent module `r3/ls.py` (prefix normalization,
GLOB-literal escaping, the self-or-children query, and partition + format) plus a
thin CLI command.

## Test plan

- [x] `test/test_ls.py` — unit tests for the pure logic: partition into
  self/leaf/dir, collisions (both lines), revision grouping (latest wins), root
  listing, no-path exclusion, alphabetical and `-t` ordering, GLOB escaping, and
  formatting (default / `-l` / `--no-tags`).
- [x] `test/test_cli.py` — `r3 ls` integration: one-level listing (incl. exact
  line count / directory collapse), the `.` self-entry, a leaf/dir collision,
  revision count + latest timestamp, root, trailing-slash equivalence, empty
  result, `-l` / `--no-tags`, and `-t`.
- [x] Full suite + `ruff` + `mypy` green.

## Deferred (out of scope)

`find -q/--query`, parameter-bound queries in `query.py`, dependency
`find_latest`/`find_all` path sugar, and a path-hygiene lint.
